### PR TITLE
Fix crash on Android 10 and below (API < 30)

### DIFF
--- a/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
+++ b/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
@@ -115,32 +115,38 @@ class ConnectionService : Service() {
 
     fun connect(serverIp: String, screenName: String) {
         scope.launch {
-            startForeground(NOTIF_ID, NotificationHelper.build(this@ConnectionService, stateMachine.state.value))
-            stateMachine.onConnecting(serverIp)
-            val conn = InputLeapConnection(serverIp) { cert ->
-                val newFp = TlsFingerprintManager.fingerprintOf(cert)
-                val storedFp = prefs.fingerprintFor(serverIp).first()
-                val trusted = when {
-                    storedFp == null -> {
-                        // First connect: ask user to confirm
-                        onFingerprintConfirmationRequired?.invoke(serverIp, newFp, null) ?: false
+            try {
+                startForeground(NOTIF_ID, NotificationHelper.build(this@ConnectionService, stateMachine.state.value))
+                stateMachine.onConnecting(serverIp)
+                val conn = InputLeapConnection(serverIp) { cert ->
+                    val newFp = TlsFingerprintManager.fingerprintOf(cert)
+                    val storedFp = prefs.fingerprintFor(serverIp).first()
+                    val trusted = when {
+                        storedFp == null -> {
+                            // First connect: ask user to confirm
+                            onFingerprintConfirmationRequired?.invoke(serverIp, newFp, null) ?: false
+                        }
+                        storedFp == newFp -> true  // auto-trust — same cert
+                        else -> {
+                            // Cert changed: warn user
+                            onFingerprintConfirmationRequired?.invoke(serverIp, newFp, storedFp) ?: false
+                        }
                     }
-                    storedFp == newFp -> true  // auto-trust — same cert
-                    else -> {
-                        // Cert changed: warn user
-                        onFingerprintConfirmationRequired?.invoke(serverIp, newFp, storedFp) ?: false
-                    }
+                    if (trusted) prefs.saveFingerprint(serverIp, newFp)
+                    trusted
                 }
-                if (trusted) prefs.saveFingerprint(serverIp, newFp)
-                trusted
+                val banner = conn.connect()
+                if (banner == null) { stateMachine.onDisconnected(); scheduleRetry(serverIp, screenName); return@launch }
+                retryAttempt = 0
+                connection = conn
+                stateMachine.onHandshaking(serverIp)
+                withContext(Dispatchers.IO) { conn.sendHelloBack(screenName) }
+                startEventLoop(conn, serverIp, screenName)
+            } catch (e: Exception) {
+                Log.w(TAG, "Connection to $serverIp failed: ${e.javaClass.simpleName}: ${e.message}")
+                stateMachine.onDisconnected()
+                scheduleRetry(serverIp, screenName)
             }
-            val banner = conn.connect()
-            if (banner == null) { stateMachine.onDisconnected(); scheduleRetry(serverIp, screenName); return@launch }
-            retryAttempt = 0
-            connection = conn
-            stateMachine.onHandshaking(serverIp)
-            withContext(Dispatchers.IO) { conn.sendHelloBack(screenName) }
-            startEventLoop(conn, serverIp, screenName)
         }
     }
 

--- a/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
+++ b/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
@@ -142,8 +142,10 @@ class ConnectionService : Service() {
                 stateMachine.onHandshaking(serverIp)
                 withContext(Dispatchers.IO) { conn.sendHelloBack(screenName) }
                 startEventLoop(conn, serverIp, screenName)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                Log.w(TAG, "Connection to $serverIp failed: ${e.javaClass.simpleName}: ${e.message}")
+                Log.w(TAG, "Connection to $serverIp failed: ${e.javaClass.simpleName}: ${e.message}", e)
                 stateMachine.onDisconnected()
                 scheduleRetry(serverIp, screenName)
             }

--- a/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
+++ b/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
@@ -2,7 +2,10 @@ package com.inputleaf.android.service
 
 import android.app.Service
 import android.content.Intent
+import android.graphics.Point
+import android.graphics.Rect
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
 import android.util.Log
@@ -53,8 +56,7 @@ class ConnectionService : Service() {
         observeState()
         
         // Get screen dimensions
-        val wm = getSystemService(WindowManager::class.java)
-        val bounds = wm.currentWindowMetrics.bounds
+        val bounds = getScreenBounds()
         screenWidth = bounds.width()
         screenHeight = bounds.height()
         
@@ -144,8 +146,7 @@ class ConnectionService : Service() {
 
     private fun startEventLoop(conn: InputLeapConnection, ip: String, screenName: String) {
         scope.launch(Dispatchers.IO) {
-            val wm = getSystemService(WindowManager::class.java)
-            val bounds = wm.currentWindowMetrics.bounds
+            val bounds = getScreenBounds()
             var serverName = ""
             conn.events.collect { event ->
                 when (event) {
@@ -255,8 +256,7 @@ class ConnectionService : Service() {
      * @return true if Shizuku is available and bound successfully
      */
     suspend fun connectShizukuInjector(): Boolean = withContext(Dispatchers.IO) {
-        val wm = getSystemService(WindowManager::class.java)
-        val bounds = wm.currentWindowMetrics.bounds
+        val bounds = getScreenBounds()
         val injector = ShizukuInputInjector(bounds.width(), bounds.height())
         
         if (injector.isAvailable()) {
@@ -335,6 +335,23 @@ class ConnectionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_DISCONNECT) disconnect()
         return START_STICKY
+    }
+
+    /**
+     * Returns the screen bounds in a backward-compatible way.
+     * Uses WindowManager.currentWindowMetrics (API 30+) when available,
+     * otherwise falls back to the deprecated Display.getSize().
+     */
+    @Suppress("DEPRECATION")
+    private fun getScreenBounds(): Rect {
+        val wm = getSystemService(WindowManager::class.java)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            wm.currentWindowMetrics.bounds
+        } else {
+            val size = Point()
+            wm.defaultDisplay.getSize(size)
+            Rect(0, 0, size.x, size.y)
+        }
     }
 
     override fun onDestroy() { 


### PR DESCRIPTION
## Summary

Fixes a `NoSuchMethodError` crash when running on devices with Android 10 (API 29) or lower. The app's `minSdk` is 26 but `ConnectionService` was calling `WindowManager.getCurrentWindowMetrics()`, which is only available on API 30+.

Additionally fixes an unhandled `ConnectException` that causes a fatal crash when the server is unreachable, instead of gracefully retrying.

## Changes

### `ConnectionService.kt`

- **Backward-compatible screen dimensions**: Added a `getScreenBounds()` helper that uses `WindowManager.currentWindowMetrics` on API 30+ and falls back to the deprecated `Display.getSize()` on older APIs. Replaced all 3 direct calls to `currentWindowMetrics`.

- **Graceful connection error handling**: Wrapped the `connect()` coroutine body in a try-catch so that network errors (e.g. `ConnectException` when the server isn't running) are logged and trigger a retry instead of crashing the app.

## Testing

- Verified the app launches and runs without crashing on an Android 10 tablet (API 29).
- Verified connection failures are handled gracefully with automatic retry.

## Summary by Sourcery

Handle connection and screen sizing in a backward-compatible way to prevent crashes on older Android devices.

Bug Fixes:
- Prevent NoSuchMethodError crashes on Android API levels below 30 by avoiding direct use of WindowManager.currentWindowMetrics.
- Handle connection failures (e.g., unreachable server) without crashing by catching exceptions and triggering the existing retry logic.

Enhancements:
- Introduce a reusable getScreenBounds() helper that computes screen dimensions using API-appropriate WindowManager methods.