### PR TITLE
Add fast JVM test foundation and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run fast JVM tests
-        run: ./gradlew --no-daemon :app:testDebugUnitTest :uhid-server:test
+        run: ./gradlew --no-daemon --stacktrace :app:testDebugUnitTest :uhid-server:test
 
       - name: Upload failed test reports
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fast-jvm:
+    name: fast-jvm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run fast JVM tests
+        run: ./gradlew --no-daemon :app:testDebugUnitTest :uhid-server:test
+
+      - name: Upload failed test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-jvm-test-reports
+          path: |
+            app/build/reports/tests/
+            app/build/test-results/
+            uhid-server/build/reports/tests/
+            uhid-server/build/test-results/
+          if-no-files-found: warn
+          retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,5 +100,5 @@ dependencies {
     
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-    testImplementation("com.google.truth:truth:1.4.0")
+    testImplementation("com.google.truth:truth:1.4.5")
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,72 @@
+# Testing
+
+Input Leaf uses a small, fast JVM test suite as the main feedback loop for local development and pull requests. Android emulator tests and coverage enforcement will be added separately so they do not slow down this required check.
+
+## Requirements
+
+- JDK 17
+- Android SDK platform 34 and build tools 34.0.0
+- The checked-in Gradle Wrapper (`./gradlew`)
+
+## Run the fast suite
+
+From the repository root, run:
+
+```sh
+./gradlew :app:testDebugUnitTest :uhid-server:test
+```
+
+The same command runs in the `fast-jvm` GitHub Actions job. The app task runs local Android JVM tests. The UHID task runs plain Java JVM tests and may report `NO-SOURCE` until tests are added to that module.
+
+## Test locations and conventions
+
+### Android app
+
+Place app JVM tests under:
+
+```text
+app/src/test/java/com/inputleaf/android/<feature>/
+```
+
+Mirror the production package, name classes after the subject with a `Test` suffix, and follow the existing JUnit 4, Truth, and behavior-oriented naming conventions. Put deterministic file fixtures in `app/src/test/resources/`.
+
+### UHID server
+
+Place UHID JVM tests under:
+
+```text
+uhid-server/src/test/java/com/inputleaf/uhid/
+```
+
+The UHID module is Java-only. Keep its tests in Java so test coverage does not add the Kotlin plugin or runtime to the generated JAR and DEX pipeline. Use JUnit 4 and Truth.
+
+## Test design principles
+
+- Test observable results, emitted events, persisted values, errors, and protocol bytes rather than private methods or collaborator call order.
+- Prefer pure JVM tests over emulator tests when Android behavior is not the subject of the test.
+- Control time, asynchronous work, network responses, and fixture data so tests are deterministic.
+- Use byte streams, loopback sockets, and small fakes instead of external services, LAN devices, privileged APIs, or physical hardware.
+- Give each test independent state and explicit cleanup.
+- Do not add retries or arbitrary sleeps to hide flaky behavior.
+- Keep fixtures local to a test unless sharing clearly reduces duplication.
+
+## Suite boundaries
+
+The required pull-request suite must not depend on:
+
+- an Android emulator or connected device;
+- a Deskflow installation or external server;
+- LAN or Internet access during tests;
+- Shizuku, accessibility, IME, or `/dev/uhid` access;
+- APK signing or release secrets.
+
+A small emulator smoke suite and coverage guardrails are planned as later, separate work. Lint and formatting are not part of the required test command because the repository does not currently configure dedicated formatting or static-analysis tooling.
+
+## Current baseline
+
+The initial baseline was verified with JDK 17 and Android SDK 34 when the fast CI workflow was introduced:
+
+- `:app:testDebugUnitTest` passes.
+- `:uhid-server:test` is configured and currently reports `NO-SOURCE`; UHID tests are planned as follow-up work.
+
+Before making changes, run the complete fast suite and treat failures as real regressions or document them explicitly. Do not skip, mute, or retry failing tests merely to produce a green build. GitHub Actions retains available test reports when the `fast-jvm` job fails.

--- a/uhid-server/build.gradle.kts
+++ b/uhid-server/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     compileOnly("com.google.android:android:4.1.1.4")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("com.google.truth:truth:1.4.0")
+    testImplementation("com.google.truth:truth:1.4.5")
 }
 // Step 1: fat JAR
 tasks.register<Jar>("fatJar") {

--- a/uhid-server/build.gradle.kts
+++ b/uhid-server/build.gradle.kts
@@ -6,6 +6,9 @@ java {
 dependencies {
     // Android stub for android.net.LocalServerSocket / LocalSocket (compile-time only)
     compileOnly("com.google.android:android:4.1.1.4")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("com.google.truth:truth:1.4.0")
 }
 // Step 1: fat JAR
 tasks.register<Jar>("fatJar") {


### PR DESCRIPTION
## Summary

- add a `fast-jvm` GitHub Actions job for app and UHID JVM tests
- configure JUnit 4 and Truth for the Java-only `uhid-server` module
- document local commands, test conventions, suite boundaries, and the verified baseline
- cache Gradle dependencies, cancel superseded runs, and retain reports on failures

This keeps emulator tests, coverage enforcement, APK assembly, signing, and unrelated lint tooling outside the initial required pipeline as planned in #8.

## Validation

- `./gradlew :app:testDebugUnitTest :uhid-server:test`
  - app JVM tests pass
  - UHID test task is configured and currently reports `NO-SOURCE`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Maintainer action required

Because this PR introduces a GitHub Actions workflow from a fork, GitHub may hold the workflow until an upstream maintainer approves it.

Please:

1. Review `.github/workflows/ci.yml`.
2. Open this PR’s **Checks** tab, or find the pending run in the repository’s **Actions** tab.
3. Click **Approve and run workflows**.
4. Confirm that the `fast-jvm` job succeeds before merging.

Only a maintainer with write access to the upstream repository can approve the run.

Closes #9

## Summary by Sourcery

Establish a fast, documented JVM testing foundation for local development and pull requests.

New Features:
- Add a required fast JVM test workflow covering app unit tests and the UHID server test task.
- Establish JUnit 4 and Truth support for Java tests in the UHID server module.

Enhancements:
- Define project-wide JVM testing conventions, suite boundaries, and the current verified baseline.

CI:
- Configure JDK 17 and Android SDK setup, Gradle dependency caching, superseded-run cancellation, and failure report retention for the fast JVM CI job.

Documentation:
- Add local testing instructions and guidance for test organization and design.
