### PR TITLE
fix: explicit TLS and stable Deskflow handshake

### DIFF
--- a/app/src/main/java/com/inputleaf/android/network/ConnectResult.kt
+++ b/app/src/main/java/com/inputleaf/android/network/ConnectResult.kt
@@ -1,9 +1,24 @@
 package com.inputleaf.android.network
 
 sealed class ConnectResult {
-    data class Ok(val banner: InputLeapConnection.ServerBanner, val transport: ServerTransport) : ConnectResult()
+    data class Ok(
+        val banner: InputLeapConnection.ServerBanner,
+        val transport: ServerTransport,
+    ) : ConnectResult()
+
     data object RejectedByUser : ConnectResult()
-    data object NetworkError : ConnectResult()
+
+    data class Failed(val reason: FailureReason, val detail: String? = null) : ConnectResult()
+
+    enum class FailureReason {
+        NETWORK,
+        /** TLS was enabled but the peer spoke plain Barrier/Deskflow. */
+        TLS_AGAINST_PLAIN_SERVER,
+        /** Protocol handshake incomplete or rejected (EICV/EBSY). */
+        HANDSHAKE,
+        INCOMPATIBLE,
+        BUSY,
+    }
 }
 
 enum class ServerTransport {

--- a/app/src/main/java/com/inputleaf/android/network/ConnectionConfig.kt
+++ b/app/src/main/java/com/inputleaf/android/network/ConnectionConfig.kt
@@ -1,0 +1,33 @@
+package com.inputleaf.android.network
+
+/**
+ * Immutable connection transport settings chosen by the user.
+ *
+ * @param tlsEnabled when false, only plain TCP; when true, only TLS (no fallback).
+ * @param pinnedFingerprint SHA-256 of a previously trusted server cert, or null for TOFU.
+ * @param clientCertificate PKCS12 bytes for optional mutual TLS, or null.
+ * @param clientCertificatePassword password for [clientCertificate], or null.
+ */
+data class ConnectionConfig(
+    val tlsEnabled: Boolean = false,
+    val pinnedFingerprint: String? = null,
+    val clientCertificate: ByteArray? = null,
+    val clientCertificatePassword: CharArray? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ConnectionConfig) return false
+        return tlsEnabled == other.tlsEnabled &&
+            pinnedFingerprint == other.pinnedFingerprint &&
+            clientCertificate.contentEquals(other.clientCertificate) &&
+            clientCertificatePassword.contentEquals(other.clientCertificatePassword)
+    }
+
+    override fun hashCode(): Int {
+        var result = tlsEnabled.hashCode()
+        result = 31 * result + (pinnedFingerprint?.hashCode() ?: 0)
+        result = 31 * result + (clientCertificate?.contentHashCode() ?: 0)
+        result = 31 * result + (clientCertificatePassword?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/app/src/main/java/com/inputleaf/android/network/TlsFingerprintManager.kt
+++ b/app/src/main/java/com/inputleaf/android/network/TlsFingerprintManager.kt
@@ -1,7 +1,11 @@
 package com.inputleaf.android.network
 
+import java.io.ByteArrayInputStream
+import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.cert.X509Certificate
+import javax.net.ssl.KeyManager
+import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLException
 import javax.net.ssl.X509TrustManager
@@ -14,7 +18,11 @@ object TlsFingerprintManager {
         return hash.joinToString("") { "%02x".format(it) }
     }
 
-    fun buildPinningSSLContext(expectedFingerprint: String): SSLContext {
+    fun buildPinningSSLContext(
+        expectedFingerprint: String,
+        clientCertificate: ByteArray? = null,
+        clientCertificatePassword: CharArray? = null,
+    ): SSLContext {
         val trustManager = object : X509TrustManager {
             override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
             override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
@@ -25,7 +33,11 @@ object TlsFingerprintManager {
             }
         }
         return SSLContext.getInstance("TLS").also {
-            it.init(null, arrayOf(trustManager), null)
+            it.init(
+                keyManagers(clientCertificate, clientCertificatePassword),
+                arrayOf(trustManager),
+                null,
+            )
         }
     }
 
@@ -35,7 +47,11 @@ object TlsFingerprintManager {
      * bypassed. Use for exactly one connection to capture the server certificate fingerprint.
      * After the user confirms, build a pinning SSLContext for all subsequent connections.
      */
-    fun buildCapturingSSLContext(onCertificate: (X509Certificate) -> Unit): SSLContext {
+    fun buildCapturingSSLContext(
+        clientCertificate: ByteArray? = null,
+        clientCertificatePassword: CharArray? = null,
+        onCertificate: (X509Certificate) -> Unit,
+    ): SSLContext {
         val trustManager = object : X509TrustManager {
             override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
             override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
@@ -44,7 +60,25 @@ object TlsFingerprintManager {
             }
         }
         return SSLContext.getInstance("TLS").also {
-            it.init(null, arrayOf(trustManager), null)
+            it.init(
+                keyManagers(clientCertificate, clientCertificatePassword),
+                arrayOf(trustManager),
+                null,
+            )
         }
+    }
+
+    fun keyManagers(
+        clientCertificate: ByteArray?,
+        clientCertificatePassword: CharArray?,
+    ): Array<KeyManager>? {
+        if (clientCertificate == null || clientCertificate.isEmpty()) return null
+        val password = clientCertificatePassword ?: CharArray(0)
+        val keyStore = KeyStore.getInstance("PKCS12").apply {
+            load(ByteArrayInputStream(clientCertificate), password)
+        }
+        return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+            init(keyStore, password)
+        }.keyManagers
     }
 }

--- a/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
+++ b/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
@@ -1,0 +1,9 @@
+package com.inputleaf.android.network
+
+/**
+ * Explicit TLS vs plain selection. Never probes both in one connect attempt.
+ */
+object TransportPolicy {
+    fun order(tlsEnabled: Boolean): List<ServerTransport> =
+        if (tlsEnabled) listOf(ServerTransport.TLS) else listOf(ServerTransport.PLAIN)
+}

--- a/app/src/main/java/com/inputleaf/android/protocol/ProtocolConstants.kt
+++ b/app/src/main/java/com/inputleaf/android/protocol/ProtocolConstants.kt
@@ -3,7 +3,7 @@ package com.inputleaf.android.protocol
 object ProtocolConstants {
     const val DEFAULT_PORT = 24800
     const val PROTOCOL_MAJOR = 1
-    const val PROTOCOL_MINOR = 6
+    const val PROTOCOL_MINOR = 8
     const val MAX_MESSAGE_LEN = 4 * 1024 * 1024
 
     // Server→Client tags


### PR DESCRIPTION
## Summary
- Replace TLS/plain auto-probe with an explicit **Use TLS** setting (default off) so plain Deskflow no longer gets a TLS probe that drops after Barrier hello
- Optional PKCS12 client certificate for Deskflow mTLS when TLS is on
- Echo Barrier/Synergy hello magic; negotiate protocol up to v1.8; surface EICV/EBSY/TLS-mismatch without retry storms
- Keep Android 16 Shizuku InputManagerGlobal injection, mouse button press/release, injector rebind, and main-thread accessibility gestures
- Add JVM transport + fake-server handshake + client-cert tests so GitHub CI catches the next break

## Test plan
- [ ] Settings → Use TLS off → connect to plain Deskflow → stable connection
- [ ] Settings → Use TLS on against plain Deskflow → clear error, no retry storm
- [ ] Mouse/keyboard via Shizuku on Android 16
- [ ] `./gradlew :app:testDebugUnitTest` passes

Split from PR #22 (languages-only).

Note: full file push may still be landing on the branch; if CI fails on missing files, wait for the branch to finish updating.

## Summary by Sourcery

Make Deskflow connections use an explicit transport mode and stable protocol handshake with clearer failures and optional mutual TLS.

New Features:
- Add explicit user-selected TLS or plain transport with optional PKCS12 client-certificate support.
- Support protocol negotiation through version 1.8.

Bug Fixes:
- Prevent TLS probing from destabilizing plain Deskflow connections and provide distinct failures for TLS mismatches, handshake rejection, incompatibility, busy servers, and network errors.

Enhancements:
- Improve TLS certificate handling with fingerprint pinning, trust-on-first-use capture, and optional mutual TLS credentials.

Tests:
- Add transport and handshake coverage, including fake-server and client-certificate scenarios.