### PR TITLE
fix: support Deskflow Barrier and Synergy handshakes

### DIFF
--- a/app/src/main/java/com/inputleaf/android/model/InputLeapEvent.kt
+++ b/app/src/main/java/com/inputleaf/android/model/InputLeapEvent.kt
@@ -1,8 +1,18 @@
 package com.inputleaf.android.model
 
+enum class WireProtocol(val magic: String) {
+    BARRIER("Barrier"),
+    SYNERGY("Synergy"),
+}
+
 sealed class InputLeapEvent {
     // Handshake
-    data class Hello(val majorVersion: Int, val minorVersion: Int, val serverName: String) : InputLeapEvent()
+    data class Hello(
+        val majorVersion: Int,
+        val minorVersion: Int,
+        val serverName: String,
+        val protocol: WireProtocol = WireProtocol.BARRIER,
+    ) : InputLeapEvent()
     data class QueryInfo(val dummy: Unit = Unit) : InputLeapEvent()
     // Control
     data class Enter(val x: Int, val y: Int, val seqNum: Int, val mask: Int) : InputLeapEvent()

--- a/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
+++ b/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
@@ -2,6 +2,7 @@ package com.inputleaf.android.network
 
 import android.util.Log
 import com.inputleaf.android.model.InputLeapEvent
+import com.inputleaf.android.protocol.ProtocolConstants
 import com.inputleaf.android.protocol.ProtocolParser
 import com.inputleaf.android.protocol.ProtocolWriter
 import kotlinx.coroutines.CancellationException
@@ -44,6 +45,7 @@ class InputLeapConnection(
     private val readerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var readJob: Job? = null
 
+    /** Version advertised by the server before client-side minor-version negotiation. */
     data class ServerBanner(val major: Int, val minor: Int)
 
     suspend fun connect(screenName: String, screenWidth: Int, screenHeight: Int): ConnectResult =
@@ -180,8 +182,8 @@ class InputLeapConnection(
         var helloSent = false
         var dinfSent = false
         var sawPostDinf = false
-        var bannerMajor = 1
-        var bannerMinor = 6
+        var bannerMajor = ProtocolConstants.PROTOCOL_MAJOR
+        var bannerMinor = ProtocolConstants.PROTOCOL_MINOR
 
         try {
             repeat(32) {
@@ -192,9 +194,21 @@ class InputLeapConnection(
                         bannerMajor = event.majorVersion
                         bannerMinor = event.minorVersion
                         if (!helloSent) {
-                            writer?.writeHelloBack(screenName, 1, 6)
+                            val negotiatedProtocol = event.protocol
+                            val negotiatedMinor =
+                                ProtocolConstants.negotiateMinor(event.minorVersion)
+                            writer?.writeHelloBack(
+                                screenName = screenName,
+                                major = ProtocolConstants.PROTOCOL_MAJOR,
+                                minor = negotiatedMinor,
+                                protocol = negotiatedProtocol,
+                            )
                             helloSent = true
-                            Log.d(TAG, "Handshake sent client hello as $screenName")
+                            Log.d(
+                                TAG,
+                                "Handshake sent ${negotiatedProtocol.magic} client hello " +
+                                    "as $screenName using 1.$negotiatedMinor",
+                            )
                         }
                     }
                     is InputLeapEvent.QueryInfo -> {
@@ -265,7 +279,6 @@ class InputLeapConnection(
         runCatching { socket?.soTimeout = 0 }
     }
 
-    fun sendHelloBack(screenName: String) = writer?.writeHelloBack(screenName, 1, 6)
     fun sendDataInfo(w: Int, h: Int) = writer?.writeDataInfo(w, h, 0, 0, 0, 0)
     fun sendKeepAlive() = writer?.writeKeepAlive()
     fun sendInfoAck() = writer?.writeInfoAck()

--- a/app/src/main/java/com/inputleaf/android/network/ServerScanner.kt
+++ b/app/src/main/java/com/inputleaf/android/network/ServerScanner.kt
@@ -1,6 +1,8 @@
 package com.inputleaf.android.network
 
+import android.util.Log
 import com.inputleaf.android.model.ServerInfo
+import com.inputleaf.android.model.WireProtocol
 import com.inputleaf.android.protocol.ProtocolConstants
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Semaphore
@@ -10,20 +12,26 @@ import java.io.InputStream
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.security.cert.X509Certificate
-import android.util.Log
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.X509TrustManager
 
 class ServerScanner {
     companion object {
-        private const val BARRIER_TAG = "Barr"
-
         fun subnetHosts(deviceIp: String): List<String> {
             val parts = deviceIp.split(".")
             require(parts.size == 4) { "Expected a valid IPv4 address, got: $deviceIp" }
             val prefix = "${parts[0]}.${parts[1]}.${parts[2]}"
             return (1..254).map { "$prefix.$it" }.filter { it != deviceIp }
+        }
+
+        internal fun parseHello(host: String, body: ByteArray): ServerInfo? {
+            if (body.size < 11) return null
+            val magic = String(body, 0, 7, Charsets.US_ASCII)
+            if (WireProtocol.entries.none { it.magic == magic }) return null
+            val major = ((body[7].toInt() and 0xFF) shl 8) or (body[8].toInt() and 0xFF)
+            val minor = ((body[9].toInt() and 0xFF) shl 8) or (body[10].toInt() and 0xFF)
+            return ServerInfo(ip = host, name = "InputLeap $major.$minor")
         }
 
         private val trustAllSslContext: SSLContext by lazy {
@@ -82,18 +90,14 @@ class ServerScanner {
     }
 
     /**
-     * InputLeap HELLO: 4-byte length prefix + "Barrier" (7 bytes) + major (2B) + minor (2B).
-     * Length should be 11; first 4 bytes of body are "Barr".
+     * Deskflow HELLO: 4-byte length prefix + seven-byte Barrier/Synergy magic +
+     * major (2B) + minor (2B).
      */
     private fun readHello(host: String, din: DataInputStream): ServerInfo? {
         val len = din.readInt()
         if (len < 11 || len > 256) return null
         val body = ByteArray(minOf(len, 11))
         din.readFully(body)
-        val tag = String(body, 0, 4, Charsets.US_ASCII)
-        if (tag != BARRIER_TAG) return null
-        val major = ((body[7].toInt() and 0xFF) shl 8) or (body[8].toInt() and 0xFF)
-        val minor = ((body[9].toInt() and 0xFF) shl 8) or (body[10].toInt() and 0xFF)
-        return ServerInfo(ip = host, name = "InputLeap $major.$minor")
+        return parseHello(host, body)
     }
 }

--- a/app/src/main/java/com/inputleaf/android/protocol/ProtocolConstants.kt
+++ b/app/src/main/java/com/inputleaf/android/protocol/ProtocolConstants.kt
@@ -6,6 +6,8 @@ object ProtocolConstants {
     const val PROTOCOL_MINOR = 6
     const val MAX_MESSAGE_LEN = 4 * 1024 * 1024
 
+    fun negotiateMinor(serverMinor: Int): Int = minOf(serverMinor, PROTOCOL_MINOR)
+
     // Server→Client tags
     const val TAG_HELLO         = "HELO"
     const val TAG_QUERY_INFO    = "QINF"

--- a/app/src/main/java/com/inputleaf/android/protocol/ProtocolParser.kt
+++ b/app/src/main/java/com/inputleaf/android/protocol/ProtocolParser.kt
@@ -1,6 +1,7 @@
 package com.inputleaf.android.protocol
 
 import com.inputleaf.android.model.InputLeapEvent
+import com.inputleaf.android.model.WireProtocol
 import java.io.DataInputStream
 import java.io.EOFException
 import java.io.InputStream
@@ -20,16 +21,18 @@ class ProtocolParser(input: DataInputStream) {
         }
         val body = ByteArray(length).also { input.readFully(it) }
         when {
-            body.startsWithAscii("Barrier") -> parseHello(body, "Barrier")
-            body.startsWithAscii("Synergy") -> parseHello(body, "Synergy")
+            body.startsWithAscii(WireProtocol.BARRIER.magic) ->
+                parseHello(body, WireProtocol.BARRIER)
+            body.startsWithAscii(WireProtocol.SYNERGY.magic) ->
+                parseHello(body, WireProtocol.SYNERGY)
             else -> parse(body.protocolTag(), body.copyOfRange(4, body.size))
         }
     } catch (e: EOFException) {
         protocolError("Truncated protocol message", e)
     }
 
-    private fun parseHello(body: ByteArray, tag: String): InputLeapEvent {
-        requireAtLeast(body.size, 11, "body", tag)
+    private fun parseHello(body: ByteArray, protocol: WireProtocol): InputLeapEvent {
+        requireAtLeast(body.size, 11, "body", protocol.magic)
         val major = body.u16(7)
         val minor = body.u16(9)
         val name = if (body.size == 11) {
@@ -37,14 +40,14 @@ class ProtocolParser(input: DataInputStream) {
         } else {
             if (body.size < 15) {
                 protocolError(
-                    "Malformed $tag message: expected 11 or at least 15 body bytes, got ${body.size}"
+                    "Malformed ${protocol.magic} message: expected 11 or at least 15 body bytes, got ${body.size}"
                 )
             }
             val nameLength = body.u32(11)
-            requireExact(body.size.toLong(), 15L + nameLength, "body", tag)
-            body.utf8(15, nameLength, tag)
+            requireExact(body.size.toLong(), 15L + nameLength, "body", protocol.magic)
+            body.utf8(15, nameLength, protocol.magic)
         }
-        return InputLeapEvent.Hello(major, minor, name)
+        return InputLeapEvent.Hello(major, minor, name, protocol)
     }
 
     private fun parse(tag: String, payload: ByteArray): InputLeapEvent = when (tag) {

--- a/app/src/main/java/com/inputleaf/android/protocol/ProtocolWriter.kt
+++ b/app/src/main/java/com/inputleaf/android/protocol/ProtocolWriter.kt
@@ -1,15 +1,21 @@
 package com.inputleaf.android.protocol
 
+import com.inputleaf.android.model.WireProtocol
 import java.io.DataOutputStream
 import java.io.OutputStream
 
 class ProtocolWriter(output: OutputStream) {
     private val dout = DataOutputStream(output)
 
-    fun writeHelloBack(screenName: String, major: Int, minor: Int) {
+    fun writeHelloBack(
+        screenName: String,
+        major: Int,
+        minor: Int,
+        protocol: WireProtocol = WireProtocol.BARRIER,
+    ) {
         val nameBytes = screenName.toByteArray(Charsets.UTF_8)
-        // Input Leap HelloBack uses "Barrier" as the frame tag (not "HELO")
-        frame("Barrier") {
+        // HelloBack echoes the server's seven-byte Barrier or Synergy protocol magic.
+        frame(protocol.magic) {
             writeShort(major); writeShort(minor)
             writeInt(nameBytes.size); write(nameBytes)
         }

--- a/app/src/main/java/com/inputleaf/android/shizuku/HiddenInputManager.kt
+++ b/app/src/main/java/com/inputleaf/android/shizuku/HiddenInputManager.kt
@@ -21,39 +21,38 @@ internal object HiddenInputManager {
         val injectMethod: Method
     )
 
-    fun resolve(): Target? {
+    fun resolve(): Target? = resolveFrom(productionAttempts())
+
+    internal fun resolveFrom(attempts: List<() -> Target?>): Target? {
         return try {
-            resolveOrNull()
+            for (attempt in attempts) {
+                try {
+                    val target = attempt()
+                    if (target != null) {
+                        logInfo(
+                            "Using ${target.instance.javaClass.name}#${target.injectMethod.name}" +
+                                "(${target.injectMethod.parameterCount} args)"
+                        )
+                        return target
+                    }
+                } catch (e: Throwable) {
+                    logWarn("Input manager resolve attempt failed", e)
+                }
+            }
+            logError("No InputManager injectInputEvent available")
+            null
         } catch (e: Throwable) {
             logError("No InputManager injectInputEvent available", e)
             null
         }
     }
 
-    private fun resolveOrNull(): Target? {
-        val attempts = listOf(
-            { fromNamedSingleton("android.hardware.input.InputManagerGlobal") },
-            { fromNamedSingleton("android.hardware.input.InputManager") },
-            { fromApplicationInputService() },
-            { fromIInputManagerBinder() }
-        )
-        for (attempt in attempts) {
-            try {
-                val target = attempt()
-                if (target != null) {
-                    logInfo(
-                        "Using ${target.instance.javaClass.name}#${target.injectMethod.name}" +
-                            "(${target.injectMethod.parameterCount} args)"
-                    )
-                    return target
-                }
-            } catch (e: Throwable) {
-                logWarn("Input manager resolve attempt failed", e)
-            }
-        }
-        logError("No InputManager injectInputEvent available")
-        return null
-    }
+    private fun productionAttempts(): List<() -> Target?> = listOf(
+        { fromNamedSingleton("android.hardware.input.InputManagerGlobal") },
+        { fromNamedSingleton("android.hardware.input.InputManager") },
+        { fromApplicationInputService() },
+        { fromIInputManagerBinder() }
+    )
 
     fun inject(target: Target?, event: InputEvent, mode: Int): Boolean {
         if (target == null) return false

--- a/app/src/main/java/com/inputleaf/android/shizuku/HiddenInputManager.kt
+++ b/app/src/main/java/com/inputleaf/android/shizuku/HiddenInputManager.kt
@@ -1,0 +1,185 @@
+package com.inputleaf.android.shizuku
+
+import android.util.Log
+import android.view.InputEvent
+import java.lang.reflect.Method
+
+/**
+ * Resolves a privileged [InputManager.injectInputEvent][android.hardware.input.InputManager]
+ * handle across Android versions.
+ *
+ * Android 14 removed the hidden `InputManager.getInstance()` singleton and moved injection
+ * onto `InputManagerGlobal`. Calling the old method in a Shizuku UserService constructor
+ * crashes the process and looks like a bind timeout.
+ */
+internal object HiddenInputManager {
+    private const val TAG = "HiddenInputManager"
+    private const val INVALID_UID = -1
+
+    internal data class Target(
+        val instance: Any,
+        val injectMethod: Method
+    )
+
+    fun resolve(): Target? {
+        return try {
+            resolveOrNull()
+        } catch (e: Throwable) {
+            logError("No InputManager injectInputEvent available", e)
+            null
+        }
+    }
+
+    private fun resolveOrNull(): Target? {
+        val attempts = listOf(
+            { fromNamedSingleton("android.hardware.input.InputManagerGlobal") },
+            { fromNamedSingleton("android.hardware.input.InputManager") },
+            { fromApplicationInputService() },
+            { fromIInputManagerBinder() }
+        )
+        for (attempt in attempts) {
+            try {
+                val target = attempt()
+                if (target != null) {
+                    logInfo(
+                        "Using ${target.instance.javaClass.name}#${target.injectMethod.name}" +
+                            "(${target.injectMethod.parameterCount} args)"
+                    )
+                    return target
+                }
+            } catch (e: Throwable) {
+                logWarn("Input manager resolve attempt failed", e)
+            }
+        }
+        logError("No InputManager injectInputEvent available")
+        return null
+    }
+
+    fun inject(target: Target?, event: InputEvent, mode: Int): Boolean {
+        if (target == null) return false
+        return invokeInject(target, event, mode) as? Boolean ?: false
+    }
+
+    internal fun findInjectMethod(clazz: Class<*>): Method? {
+        val candidates = collectMethods(clazz).filter { it.isInjectCandidate() }
+        return candidates.firstOrNull { it.name == "injectInputEvent" && it.parameterCount == 2 }
+            ?: candidates.firstOrNull { it.name == "injectInputEvent" && it.parameterCount == 3 }
+            ?: candidates.firstOrNull { it.name == "injectInputEventToTarget" }
+            ?: candidates.firstOrNull()
+    }
+
+    internal fun invokeInject(target: Target, event: Any, mode: Int): Any? {
+        val params = target.injectMethod.parameterTypes
+        val args = Array(params.size) { index ->
+            when (index) {
+                0 -> event
+                1 -> mode
+                else -> if (params[index] == Int::class.javaPrimitiveType) INVALID_UID else null
+            }
+        }
+        return target.injectMethod.invoke(target.instance, *args)
+    }
+
+    private fun fromNamedSingleton(className: String): Target? {
+        val clazz = Class.forName(className)
+        val instance = invokeNoArg(clazz, "getInstance") ?: return null
+        return bind(instance, clazz)
+    }
+
+    private fun fromApplicationInputService(): Target? {
+        val application = invokeNoArg(
+            Class.forName("android.app.ActivityThread"),
+            "currentApplication"
+        ) ?: return null
+        val instance = application.javaClass.methods
+            .firstOrNull { method ->
+                method.name == "getSystemService" &&
+                    method.parameterCount == 1 &&
+                    method.parameterTypes[0] == String::class.java
+            }
+            ?.invoke(application, "input")
+            ?: return null
+        return bind(instance, instance.javaClass)
+    }
+
+    private fun fromIInputManagerBinder(): Target? {
+        val binder = invoke(
+            Class.forName("android.os.ServiceManager"),
+            "getService",
+            arrayOf(String::class.java),
+            arrayOf("input")
+        ) ?: return null
+        val stub = Class.forName("android.hardware.input.IInputManager\$Stub")
+        val instance = invoke(
+            stub,
+            "asInterface",
+            arrayOf(Class.forName("android.os.IBinder")),
+            arrayOf(binder)
+        ) ?: return null
+        return bind(instance, instance.javaClass)
+    }
+
+    private fun bind(instance: Any, declaredClass: Class<*>): Target? {
+        val method = findInjectMethod(instance.javaClass) ?: findInjectMethod(declaredClass)
+        method?.isAccessible = true
+        return method?.let { Target(instance, it) }
+    }
+
+    private fun invokeNoArg(clazz: Class<*>, name: String): Any? {
+        return invoke(clazz, name, emptyArray(), emptyArray())
+    }
+
+    private fun invoke(
+        clazz: Class<*>,
+        name: String,
+        parameterTypes: Array<Class<*>>,
+        args: Array<Any?>
+    ): Any? {
+        val method = try {
+            clazz.getMethod(name, *parameterTypes)
+        } catch (_: NoSuchMethodException) {
+            clazz.getDeclaredMethod(name, *parameterTypes)
+        }
+        method.isAccessible = true
+        return method.invoke(null, *args)
+    }
+
+    private fun collectMethods(clazz: Class<*>): List<Method> {
+        val seen = LinkedHashSet<Method>()
+        var current: Class<*>? = clazz
+        while (current != null && current != Any::class.java) {
+            seen += current.methods
+            seen += current.declaredMethods
+            current = current.superclass
+        }
+        return seen.toList()
+    }
+
+    private fun Method.isInjectCandidate(): Boolean {
+        if (name != "injectInputEvent" && name != "injectInputEventToTarget") return false
+        if (parameterCount < 2) return false
+        if (parameterTypes[0].isPrimitive) return false
+        return parameterTypes[1] == Int::class.javaPrimitiveType
+    }
+
+    private fun logInfo(message: String) {
+        try {
+            Log.i(TAG, message)
+        } catch (_: Throwable) {
+        }
+    }
+
+    private fun logWarn(message: String, error: Throwable) {
+        try {
+            Log.w(TAG, message, error)
+        } catch (_: Throwable) {
+        }
+    }
+
+    private fun logError(message: String, error: Throwable? = null) {
+        try {
+            if (error != null) Log.e(TAG, message, error) else Log.e(TAG, message)
+        } catch (_: Throwable) {
+        }
+    }
+}

--- a/app/src/main/java/com/inputleaf/android/shizuku/InputInjectorService.kt
+++ b/app/src/main/java/com/inputleaf/android/shizuku/InputInjectorService.kt
@@ -13,25 +13,14 @@ import android.view.MotionEvent
  * This class is instantiated by Shizuku in a separate process with elevated privileges.
  */
 class InputInjectorService : IInputInjector.Stub() {
-    
-    private val inputManager: Any?
-    private val injectInputEventMethod: java.lang.reflect.Method?
-    
-    init {
-        // Get InputManager instance via reflection
-        // InputManager.getInstance() is a hidden API
-        val inputManagerClass = Class.forName("android.hardware.input.InputManager")
-        val getInstanceMethod = inputManagerClass.getMethod("getInstance")
-        inputManager = getInstanceMethod.invoke(null)
-        
-        // Get the injectInputEvent method
-        // Signature: boolean injectInputEvent(InputEvent event, int mode)
-        injectInputEventMethod = inputManagerClass.getMethod(
-            "injectInputEvent",
-            android.view.InputEvent::class.java,
-            Int::class.javaPrimitiveType
-        )
-    }
+
+    private val inputManager: HiddenInputManager.Target? =
+        try {
+            HiddenInputManager.resolve()
+        } catch (e: Throwable) {
+            android.util.Log.e("InputInjectorService", "Failed to resolve InputManager", e)
+            null
+        }
     
     companion object {
         // Injection mode: async (don't wait for injection to complete)
@@ -84,12 +73,12 @@ class InputInjectorService : IInputInjector.Stub() {
                 0                  // flags
             )
             
-            val result = injectInputEventMethod?.invoke(
-                inputManager, 
-                event, 
+            val result = HiddenInputManager.inject(
+                inputManager,
+                event,
                 INJECT_INPUT_EVENT_MODE_ASYNC
-            ) as? Boolean ?: false
-            
+            )
+
             event.recycle()
             result
         } catch (e: Exception) {
@@ -130,12 +119,12 @@ class InputInjectorService : IInputInjector.Stub() {
                 0                  // flags
             )
             
-            val result = injectInputEventMethod?.invoke(
-                inputManager, 
-                event, 
+            val result = HiddenInputManager.inject(
+                inputManager,
+                event,
                 INJECT_INPUT_EVENT_MODE_ASYNC
-            ) as? Boolean ?: false
-            
+            )
+
             event.recycle()
             result
         } catch (e: Exception) {
@@ -161,13 +150,11 @@ class InputInjectorService : IInputInjector.Stub() {
                 InputDevice.SOURCE_KEYBOARD
             )
             
-            val result = injectInputEventMethod?.invoke(
-                inputManager, 
-                event, 
+            HiddenInputManager.inject(
+                inputManager,
+                event,
                 INJECT_INPUT_EVENT_MODE_ASYNC
-            ) as? Boolean ?: false
-            
-            result
+            )
         } catch (e: Exception) {
             android.util.Log.e("InputInjectorService", "Failed to inject key event", e)
             false

--- a/app/src/test/java/com/inputleaf/android/network/ServerScannerTest.kt
+++ b/app/src/test/java/com/inputleaf/android/network/ServerScannerTest.kt
@@ -1,9 +1,20 @@
 package com.inputleaf.android.network
 
 import com.google.common.truth.Truth.assertThat
+import com.inputleaf.android.model.ServerInfo
+import com.inputleaf.android.model.WireProtocol
 import org.junit.Test
 
 class ServerScannerTest {
+    private fun hello(protocol: WireProtocol, major: Int, minor: Int): ByteArray =
+        protocol.magic.toByteArray(Charsets.US_ASCII) +
+            byteArrayOf(
+                (major shr 8).toByte(),
+                major.toByte(),
+                (minor shr 8).toByte(),
+                minor.toByte(),
+            )
+
     @Test fun `derives correct subnet from IP`() {
         val hosts = ServerScanner.subnetHosts("192.168.1.47")
         assertThat(hosts).hasSize(253) // 254 minus the device's own IP (.47)
@@ -16,5 +27,27 @@ class ServerScannerTest {
     @Test fun `excludes the device own IP`() {
         val hosts = ServerScanner.subnetHosts("192.168.1.47")
         assertThat(hosts).doesNotContain("192.168.1.47")
+    }
+
+    @Test fun `recognizes Barrier and Synergy server hello messages`() {
+        for (protocol in WireProtocol.entries) {
+            assertThat(ServerScanner.parseHello("192.168.1.10", hello(protocol, 1, 8)))
+                .isEqualTo(ServerInfo(ip = "192.168.1.10", name = "InputLeap 1.8"))
+        }
+    }
+
+    @Test fun `rejects unknown and truncated server hello messages`() {
+        assertThat(
+            ServerScanner.parseHello(
+                "192.168.1.10",
+                "Unknown".toByteArray(Charsets.US_ASCII) + byteArrayOf(0, 1, 0, 8),
+            )
+        ).isNull()
+        assertThat(
+            ServerScanner.parseHello(
+                "192.168.1.10",
+                WireProtocol.BARRIER.magic.toByteArray(Charsets.US_ASCII),
+            )
+        ).isNull()
     }
 }

--- a/app/src/test/java/com/inputleaf/android/protocol/ProtocolParserTest.kt
+++ b/app/src/test/java/com/inputleaf/android/protocol/ProtocolParserTest.kt
@@ -2,6 +2,7 @@ package com.inputleaf.android.protocol
 
 import com.google.common.truth.Truth.assertThat
 import com.inputleaf.android.model.InputLeapEvent
+import com.inputleaf.android.model.WireProtocol
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -37,16 +38,16 @@ class ProtocolParserTest {
     }
 
     @Test fun `parses Barrier and Synergy hello variants with and without a name`() {
-        for (tag in listOf("Barrier", "Synergy")) {
-            val prefix = tag.toByteArray(Charsets.US_ASCII) + u16(1) + u16(8)
+        for (protocol in WireProtocol.entries) {
+            val prefix = protocol.magic.toByteArray(Charsets.US_ASCII) + u16(1) + u16(8)
             assertThat(ProtocolParser(ByteArrayInputStream(frameOfBody(prefix))).readNext())
-                .isEqualTo(InputLeapEvent.Hello(1, 8, ""))
+                .isEqualTo(InputLeapEvent.Hello(1, 8, "", protocol))
 
             val name = "server"
             val nameBytes = name.toByteArray(Charsets.UTF_8)
             val namedHello = prefix + u32(nameBytes.size) + nameBytes
             assertThat(ProtocolParser(ByteArrayInputStream(frameOfBody(namedHello))).readNext())
-                .isEqualTo(InputLeapEvent.Hello(1, 8, name))
+                .isEqualTo(InputLeapEvent.Hello(1, 8, name, protocol))
         }
     }
 
@@ -72,24 +73,28 @@ class ProtocolParserTest {
     }
 
     @Test fun `validates Barrier and Synergy hello structure boundaries`() {
-        for (tag in listOf("Barrier", "Synergy")) {
-            val prefix = tag.toByteArray(Charsets.US_ASCII) + u16(1) + u16(8)
+        for (protocol in WireProtocol.entries) {
+            val prefix = protocol.magic.toByteArray(Charsets.US_ASCII) + u16(1) + u16(8)
 
             val shortFailure = assertThrows(ProtocolException::class.java) {
                 ProtocolParser(ByteArrayInputStream(frameOfBody(prefix.copyOf(10)))).readNext()
             }
             assertThat(shortFailure).hasMessageThat()
-                .isEqualTo("Malformed $tag message: expected at least 11 body bytes, got 10")
+                .isEqualTo(
+                    "Malformed ${protocol.magic} message: expected at least 11 body bytes, got 10"
+                )
 
             val incompleteLength = assertThrows(ProtocolException::class.java) {
                 ProtocolParser(ByteArrayInputStream(frameOfBody(prefix + byteArrayOf(0)))).readNext()
             }
             assertThat(incompleteLength).hasMessageThat()
-                .isEqualTo("Malformed $tag message: expected 11 or at least 15 body bytes, got 12")
+                .isEqualTo(
+                    "Malformed ${protocol.magic} message: expected 11 or at least 15 body bytes, got 12"
+                )
 
             val explicitEmptyName = prefix + u32(0)
             assertThat(ProtocolParser(ByteArrayInputStream(frameOfBody(explicitEmptyName))).readNext())
-                .isEqualTo(InputLeapEvent.Hello(1, 8, ""))
+                .isEqualTo(InputLeapEvent.Hello(1, 8, "", protocol))
         }
     }
 

--- a/app/src/test/java/com/inputleaf/android/protocol/ProtocolWriterTest.kt
+++ b/app/src/test/java/com/inputleaf/android/protocol/ProtocolWriterTest.kt
@@ -1,6 +1,7 @@
 package com.inputleaf.android.protocol
 
 import com.google.common.truth.Truth.assertThat
+import com.inputleaf.android.model.WireProtocol
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -76,6 +77,36 @@ class ProtocolWriterTest {
             0, 1, 0, 6,
             0, 0, 0, 0
         ))
+    }
+
+    @Test fun `echoes both protocol magics while capping a newer server minor version`() {
+        val nameBytes = "android".toByteArray(Charsets.UTF_8)
+        for (protocol in WireProtocol.entries) {
+            val (writer, output) = writerWith()
+            writer.writeHelloBack(
+                screenName = "android",
+                major = ProtocolConstants.PROTOCOL_MAJOR,
+                minor = ProtocolConstants.negotiateMinor(serverMinor = 8),
+                protocol = protocol,
+            )
+
+            assertThat(output.toByteArray()).isEqualTo(
+                frame(
+                    protocol.magic,
+                    u16(ProtocolConstants.PROTOCOL_MAJOR) +
+                        u16(ProtocolConstants.PROTOCOL_MINOR) +
+                        u32(nameBytes.size) +
+                        nameBytes,
+                )
+            )
+        }
+    }
+
+    @Test fun `caps newer protocol versions and preserves equal or older versions`() {
+        assertThat(ProtocolConstants.negotiateMinor(serverMinor = 8))
+            .isEqualTo(ProtocolConstants.PROTOCOL_MINOR)
+        assertThat(ProtocolConstants.negotiateMinor(serverMinor = 6)).isEqualTo(6)
+        assertThat(ProtocolConstants.negotiateMinor(serverMinor = 4)).isEqualTo(4)
     }
 
     @Test fun `writes complete data information frame in protocol order`() {

--- a/app/src/test/java/com/inputleaf/android/shizuku/HiddenInputManagerTest.kt
+++ b/app/src/test/java/com/inputleaf/android/shizuku/HiddenInputManagerTest.kt
@@ -1,0 +1,81 @@
+package com.inputleaf.android.shizuku
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class HiddenInputManagerTest {
+
+    @Test
+    fun `resolve does not throw`() {
+        HiddenInputManager.resolve()
+    }
+
+    @Test
+    fun `findInjectMethod prefers two-arg injectInputEvent`() {
+        val method = HiddenInputManager.findInjectMethod(TwoAndThreeArgInjector::class.java)
+        assertThat(method).isNotNull()
+        assertThat(method!!.name).isEqualTo("injectInputEvent")
+        assertThat(method.parameterCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `findInjectMethod accepts three-arg injectInputEvent`() {
+        val method = HiddenInputManager.findInjectMethod(ThreeArgInjector::class.java)
+        assertThat(method).isNotNull()
+        assertThat(method!!.name).isEqualTo("injectInputEvent")
+        assertThat(method.parameterCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `findInjectMethod falls back to injectInputEventToTarget`() {
+        val method = HiddenInputManager.findInjectMethod(TargetUidInjector::class.java)
+        assertThat(method).isNotNull()
+        assertThat(method!!.name).isEqualTo("injectInputEventToTarget")
+    }
+
+    @Test
+    fun `invokeInject fills extra int parameters with invalid uid`() {
+        val injector = RecordingInjector()
+        val method = HiddenInputManager.findInjectMethod(RecordingInjector::class.java)!!
+        method.isAccessible = true
+        val result = HiddenInputManager.invokeInject(
+            HiddenInputManager.Target(injector, method),
+            event = "down",
+            mode = 0
+        )
+        assertThat(result).isEqualTo(true)
+        assertThat(injector.event).isEqualTo("down")
+        assertThat(injector.mode).isEqualTo(0)
+        assertThat(injector.targetUid).isEqualTo(-1)
+    }
+
+    @Suppress("unused")
+    private class TwoAndThreeArgInjector {
+        fun injectInputEvent(event: Any, mode: Int): Boolean = true
+        fun injectInputEvent(event: Any, mode: Int, targetUid: Int): Boolean = false
+    }
+
+    @Suppress("unused")
+    private class ThreeArgInjector {
+        fun injectInputEvent(event: Any, mode: Int, targetUid: Int): Boolean = true
+    }
+
+    @Suppress("unused")
+    private class TargetUidInjector {
+        fun injectInputEventToTarget(event: Any, mode: Int, targetUid: Int): Boolean = true
+    }
+
+    private class RecordingInjector {
+        var event: Any? = null
+        var mode: Int? = null
+        var targetUid: Int? = null
+
+        @Suppress("unused")
+        fun injectInputEvent(event: Any, mode: Int, targetUid: Int): Boolean {
+            this.event = event
+            this.mode = mode
+            this.targetUid = targetUid
+            return true
+        }
+    }
+}

--- a/app/src/test/java/com/inputleaf/android/shizuku/HiddenInputManagerTest.kt
+++ b/app/src/test/java/com/inputleaf/android/shizuku/HiddenInputManagerTest.kt
@@ -6,8 +6,49 @@ import org.junit.Test
 class HiddenInputManagerTest {
 
     @Test
-    fun `resolve does not throw`() {
-        HiddenInputManager.resolve()
+    fun `resolve selects the first usable target and injects through it`() {
+        val injector = RecordingInjector()
+        val method = HiddenInputManager.findInjectMethod(RecordingInjector::class.java)!!
+        method.isAccessible = true
+        val expected = HiddenInputManager.Target(injector, method)
+        var laterAttemptRan = false
+
+        val resolved = HiddenInputManager.resolveFrom(
+            listOf(
+                { error("InputManagerGlobal missing") },
+                { expected },
+                {
+                    laterAttemptRan = true
+                    error("should not run after a usable target")
+                }
+            )
+        )
+
+        assertThat(resolved).isSameInstanceAs(expected)
+        assertThat(resolved!!.injectMethod.name).isEqualTo("injectInputEvent")
+        assertThat(resolved.injectMethod.parameterTypes.toList()).containsExactly(
+            Any::class.java,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType
+        ).inOrder()
+        assertThat(laterAttemptRan).isFalse()
+
+        val injected = HiddenInputManager.invokeInject(resolved, event = "move", mode = 0)
+        assertThat(injected).isEqualTo(true)
+        assertThat(injector.event).isEqualTo("move")
+        assertThat(injector.mode).isEqualTo(0)
+        assertThat(injector.targetUid).isEqualTo(-1)
+    }
+
+    @Test
+    fun `resolve returns null when every strategy fails`() {
+        val resolved = HiddenInputManager.resolveFrom(
+            listOf(
+                { null },
+                { throw IllegalStateException("stub InputManager") }
+            )
+        )
+        assertThat(resolved).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve whether a Deskflow server greets with the `Barrier` or `Synergy` wire protocol and echo the same seven-byte magic in HelloBack.
- Negotiate the lower server/client minor version while intentionally capping Input Leaf at protocol 1.6, preventing Deskflow from selecting unsupported 1.8 `DKDL`/`LSYN` behavior.
- Discover both Barrier-mode and Synergy-mode servers during plain and TLS scanning.
- Add parser, writer, negotiation, and discovery regression coverage for both protocol modes.
- Keep Shizuku input injection alive on Android 14+: resolve `InputManagerGlobal` (and other fallbacks) instead of crashing on the removed `InputManager.getInstance()` singleton.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :uhid-server:test :app:assembleDebug`
- [x] `git diff --check`
- [x] JVM tests cover Barrier and Synergy hello parsing/writing
- [x] JVM tests cover 1.8 server → 1.6 client negotiation and older-server downgrade
- [x] JVM tests cover Barrier and Synergy discovery
- [x] JVM tests cover InputManager inject-method selection and extra-arg filling
- [x] Manual: connect to a plain Deskflow server in Barrier mode
- [x] Manual: connect to a plain Deskflow server in Synergy mode
- [x] Manual: use the connection to validate PR #22 multilingual input
- [x] Manual: Shizuku injection works on Android 14+ (no bind timeout)

## Scope

This PR includes handshake compatibility plus the Android 14+ Shizuku `InputManager` crash fix. It still excludes TLS policy, client-certificate UI/storage, and protocol 1.8 feature support.

## Summary by Sourcery

Support Barrier and Synergy handshakes while keeping protocol negotiation compatible and restoring Shizuku input injection on Android 14+.

New Features:
- Support Barrier and Synergy wire-protocol handshakes by preserving and echoing the server’s protocol magic.
- Discover both Barrier-mode and Synergy-mode servers during network scans.
- Maintain Shizuku input injection across Android versions, including Android 14+.

Bug Fixes:
- Prevent Deskflow from selecting unsupported protocol 1.8 behavior by negotiating the lower minor version and capping the client at 1.6.
- Prevent Android 14+ Shizuku services from failing when the legacy InputManager singleton is unavailable.

Tests:
- Add regression coverage for both handshake variants, version negotiation, server discovery, and InputManager injection resolution.