### PR TITLE
fix: add explicit Deskflow transport modes

### DIFF
--- a/app/src/main/java/com/inputleaf/android/network/ConnectResult.kt
+++ b/app/src/main/java/com/inputleaf/android/network/ConnectResult.kt
@@ -1,9 +1,26 @@
 package com.inputleaf.android.network
 
 sealed class ConnectResult {
-    data class Ok(val banner: InputLeapConnection.ServerBanner, val transport: ServerTransport) : ConnectResult()
+    data class Ok(
+        val banner: InputLeapConnection.ServerBanner,
+        val transport: ServerTransport,
+    ) : ConnectResult()
+
     data object RejectedByUser : ConnectResult()
-    data object NetworkError : ConnectResult()
+
+    data class Failed(
+        val reason: FailureReason,
+        val detail: String? = null,
+    ) : ConnectResult()
+
+    enum class FailureReason {
+        NETWORK,
+        TLS_AGAINST_PLAIN_SERVER,
+        CERTIFICATE_MISMATCH,
+        HANDSHAKE,
+        INCOMPATIBLE,
+        BUSY,
+    }
 }
 
 enum class ServerTransport {

--- a/app/src/main/java/com/inputleaf/android/network/ConnectionTransportPolicy.kt
+++ b/app/src/main/java/com/inputleaf/android/network/ConnectionTransportPolicy.kt
@@ -1,0 +1,32 @@
+package com.inputleaf.android.network
+
+enum class ConnectionTransportPolicy(val storageValue: String) {
+    AUTO("auto"),
+    TLS_ONLY("tls_only"),
+    PLAIN_ONLY("plain_only");
+
+    companion object {
+        fun fromStorage(value: String?): ConnectionTransportPolicy =
+            entries.firstOrNull { it.storageValue == value } ?: AUTO
+    }
+
+    fun shouldRetry(reason: ConnectResult.FailureReason): Boolean =
+        this == AUTO && when (reason) {
+            ConnectResult.FailureReason.NETWORK,
+            ConnectResult.FailureReason.HANDSHAKE -> true
+            ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER,
+            ConnectResult.FailureReason.CERTIFICATE_MISMATCH,
+            ConnectResult.FailureReason.INCOMPATIBLE,
+            ConnectResult.FailureReason.BUSY -> false
+        }
+
+    fun shouldFallbackWithinAttempt(reason: ConnectResult.FailureReason): Boolean =
+        this == AUTO && when (reason) {
+            ConnectResult.FailureReason.NETWORK,
+            ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER,
+            ConnectResult.FailureReason.HANDSHAKE -> true
+            ConnectResult.FailureReason.CERTIFICATE_MISMATCH,
+            ConnectResult.FailureReason.INCOMPATIBLE,
+            ConnectResult.FailureReason.BUSY -> false
+        }
+}

--- a/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
+++ b/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
@@ -18,6 +18,7 @@ import java.io.DataInputStream
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.security.cert.X509Certificate
+import javax.net.ssl.SSLException
 import javax.net.ssl.SSLSocket
 
 private const val TAG = "InputLeapConnection"
@@ -33,6 +34,7 @@ class InputLeapConnection(
     private val port: Int = 24800,
     private val preferredTransport: ServerTransport? = null,
     private val pinnedFingerprint: String? = null,
+    private val transportPolicy: ConnectionTransportPolicy = ConnectionTransportPolicy.AUTO,
     private val onCertificate: suspend (X509Certificate) -> Boolean,
 ) {
     private val _events = MutableSharedFlow<InputLeapEvent>(replay = 0, extraBufferCapacity = 64)
@@ -50,8 +52,12 @@ class InputLeapConnection(
 
     suspend fun connect(screenName: String, screenWidth: Int, screenHeight: Int): ConnectResult =
         withContext(Dispatchers.IO) {
-            val transports = buildTransportOrder()
-            var lastError: Exception? = null
+            val transports = TransportPolicy.order(
+                policy = transportPolicy,
+                preferredTransport = preferredTransport,
+                hasPinnedFingerprint = pinnedFingerprint != null,
+            )
+            var lastFailure: ConnectResult.Failed? = null
             for (transport in transports) {
                 when (val opened = openSocket(transport)) {
                     is SocketOpenResult.Ok -> {
@@ -62,51 +68,60 @@ class InputLeapConnection(
                             screenWidth,
                             screenHeight,
                         )
-                        if (result != null) {
+                        if (result is ConnectResult.Ok) {
                             return@withContext result
                         }
-                        lastError = Exception("Handshake failed on $transport")
+                        if (result is ConnectResult.Failed) {
+                            if (!transportPolicy.shouldFallbackWithinAttempt(result.reason)) {
+                                return@withContext result
+                            }
+                            lastFailure = selectFailureToReport(lastFailure, result)
+                        }
                     }
                     is SocketOpenResult.Rejected -> return@withContext ConnectResult.RejectedByUser
-                    is SocketOpenResult.Failed -> lastError = opened.error
+                    is SocketOpenResult.Failed -> {
+                        if (!transportPolicy.shouldFallbackWithinAttempt(opened.failure.reason)) {
+                            return@withContext opened.failure
+                        }
+                        lastFailure = selectFailureToReport(lastFailure, opened.failure)
+                    }
                 }
             }
-            Log.e(TAG, "All transports failed for $ip: ${lastError?.message}")
-            ConnectResult.NetworkError
+            val failure = lastFailure ?: ConnectResult.Failed(ConnectResult.FailureReason.NETWORK)
+            Log.e(TAG, "All transports failed for $ip: ${failure.reason} ${failure.detail}")
+            failure
         }
-
-    private fun buildTransportOrder(): List<ServerTransport> {
-        preferredTransport?.let { cached ->
-            val fallback = when (cached) {
-                ServerTransport.TLS -> ServerTransport.PLAIN
-                ServerTransport.PLAIN -> ServerTransport.TLS
-            }
-            return listOf(cached, fallback)
-        }
-        // No stored TLS fingerprint — plain server is likely; avoid a doomed TLS attempt first.
-        if (pinnedFingerprint == null) {
-            return listOf(ServerTransport.PLAIN, ServerTransport.TLS)
-        }
-        return listOf(ServerTransport.TLS, ServerTransport.PLAIN)
-    }
 
     private sealed class SocketOpenResult {
         data class Ok(val socket: Socket, val transport: ServerTransport) : SocketOpenResult()
         data object Rejected : SocketOpenResult()
-        data class Failed(val error: Exception) : SocketOpenResult()
+        data class Failed(val failure: ConnectResult.Failed) : SocketOpenResult()
     }
 
     private suspend fun openSocket(transport: ServerTransport): SocketOpenResult = try {
         when (transport) {
             ServerTransport.TLS -> openTlsSocket()
-            ServerTransport.PLAIN -> SocketOpenResult.Ok(openPlainSocket(), ServerTransport.PLAIN)
+            ServerTransport.PLAIN -> try {
+                SocketOpenResult.Ok(openPlainSocket(), ServerTransport.PLAIN)
+            } catch (e: Exception) {
+                Log.w(TAG, "Plain open failed for $ip: ${e.message}")
+                SocketOpenResult.Failed(
+                    ConnectResult.Failed(ConnectResult.FailureReason.NETWORK, e.message),
+                )
+            }
         }
     } catch (e: Exception) {
-        SocketOpenResult.Failed(e)
+        SocketOpenResult.Failed(
+            ConnectResult.Failed(ConnectResult.FailureReason.NETWORK, e.message),
+        )
     }
 
     private suspend fun openTlsSocket(): SocketOpenResult {
-        val connectTimeout = if (preferredTransport == ServerTransport.TLS) {
+        var openedSocket: SSLSocket? = null
+        val connectTimeout = if (
+            transportPolicy == ConnectionTransportPolicy.AUTO &&
+            preferredTransport == ServerTransport.TLS
+        ) {
             TLS_CONNECT_TIMEOUT_CACHED_MS
         } else {
             TLS_CONNECT_TIMEOUT_MS
@@ -115,6 +130,7 @@ class InputLeapConnection(
             val rawSocket = if (pinnedFingerprint != null) {
                 val sslContext = TlsFingerprintManager.buildPinningSSLContext(pinnedFingerprint)
                 val sslSock = sslContext.socketFactory.createSocket() as SSLSocket
+                openedSocket = sslSock
                 sslSock.connect(InetSocketAddress(ip, port), connectTimeout)
                 sslSock.soTimeout = TLS_HANDSHAKE_TIMEOUT_MS
                 sslSock.startHandshake()
@@ -126,29 +142,61 @@ class InputLeapConnection(
                     capturedCert = cert
                 }
                 val sslSock = sslContext.socketFactory.createSocket() as SSLSocket
+                openedSocket = sslSock
                 sslSock.connect(InetSocketAddress(ip, port), connectTimeout)
                 sslSock.soTimeout = TLS_HANDSHAKE_TIMEOUT_MS
                 sslSock.startHandshake()
                 sslSock.soTimeout = HANDSHAKE_READ_TIMEOUT_MS
                 val cert = capturedCert ?: run {
                     sslSock.close()
-                    return SocketOpenResult.Failed(IllegalStateException("No certificate captured"))
+                    openedSocket = null
+                    return SocketOpenResult.Failed(
+                        ConnectResult.Failed(
+                            ConnectResult.FailureReason.NETWORK,
+                            "No certificate captured",
+                        ),
+                    )
                 }
                 if (!onCertificate(cert)) {
                     sslSock.close()
+                    openedSocket = null
                     return SocketOpenResult.Rejected
                 }
                 sslSock
             }
             SocketOpenResult.Ok(rawSocket, ServerTransport.TLS)
         } catch (e: Exception) {
-            Log.w(TAG, "TLS open failed for $ip: ${e.message}")
-            SocketOpenResult.Failed(e)
+            runCatching { openedSocket?.close() }
+            if (isCertificateMismatch(e)) {
+                Log.w(TAG, "TLS certificate changed for $ip")
+                SocketOpenResult.Failed(
+                    ConnectResult.Failed(
+                        ConnectResult.FailureReason.CERTIFICATE_MISMATCH,
+                        e.message,
+                    ),
+                )
+            } else if (isPlainServerTlsError(e)) {
+                Log.i(TAG, "TLS required, but $ip speaks plain Deskflow")
+                SocketOpenResult.Failed(
+                    ConnectResult.Failed(
+                        ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER,
+                        e.message,
+                    ),
+                )
+            } else {
+                Log.w(TAG, "TLS open failed for $ip: ${e.message}")
+                SocketOpenResult.Failed(
+                    ConnectResult.Failed(ConnectResult.FailureReason.NETWORK, e.message),
+                )
+            }
         }
     }
 
     private fun openPlainSocket(): Socket {
-        val connectTimeout = if (preferredTransport == ServerTransport.PLAIN) {
+        val connectTimeout = if (
+            transportPolicy == ConnectionTransportPolicy.AUTO &&
+            preferredTransport == ServerTransport.PLAIN
+        ) {
             PLAIN_CONNECT_TIMEOUT_CACHED_MS
         } else {
             PLAIN_CONNECT_TIMEOUT_MS
@@ -160,17 +208,17 @@ class InputLeapConnection(
         }
     }
 
-  /**
-   * Run the Input Leap handshake synchronously before returning.
-   * Matches schengen client: server hello → client hello → QINF → DINF → LSYN/CIAK/CROP/DSOP.
-   */
+    /**
+     * Run the Input Leap handshake synchronously before returning.
+     * Matches schengen client: server hello → client hello → QINF → DINF → LSYN/CIAK/CROP/DSOP.
+     */
     private fun runHandshake(
         rawSocket: Socket,
         transport: ServerTransport,
         screenName: String,
         screenWidth: Int,
         screenHeight: Int,
-    ): ConnectResult? {
+    ): ConnectResult {
         rawSocket.tcpNoDelay = true
         socket = rawSocket
         writer = ProtocolWriter(rawSocket.outputStream)
@@ -227,10 +275,18 @@ class InputLeapConnection(
                             "CIAK", "CROP", "DSOP", "LSYN" -> if (dinfSent) sawPostDinf = true
                         }
                     }
-                    is InputLeapEvent.Incompatible, is InputLeapEvent.Busy -> {
+                    is InputLeapEvent.Incompatible -> {
                         Log.e(TAG, "Server rejected handshake: $event")
                         close()
-                        return null
+                        return ConnectResult.Failed(
+                            ConnectResult.FailureReason.INCOMPATIBLE,
+                            "Server requires ${event.major}.${event.minor}",
+                        )
+                    }
+                    is InputLeapEvent.Busy -> {
+                        Log.e(TAG, "Server rejected handshake: busy")
+                        close()
+                        return ConnectResult.Failed(ConnectResult.FailureReason.BUSY)
                     }
                     else -> Unit
                 }
@@ -244,7 +300,7 @@ class InputLeapConnection(
         } catch (e: Exception) {
             Log.e(TAG, "Handshake error: ${e.javaClass.simpleName}: ${e.message}")
             close()
-            return null
+            return ConnectResult.Failed(ConnectResult.FailureReason.HANDSHAKE, e.message)
         }
 
         // Lenient: some servers omit LSYN/CIAK/CROP/DSOP but accept DINF.
@@ -257,7 +313,10 @@ class InputLeapConnection(
 
         Log.e(TAG, "Handshake incomplete hello=$helloSent dinf=$dinfSent post=$sawPostDinf")
         close()
-        return null
+        return ConnectResult.Failed(
+            ConnectResult.FailureReason.HANDSHAKE,
+            "Incomplete handshake: hello=$helloSent, deviceInfo=$dinfSent",
+        )
     }
 
     private suspend fun readLoop(parser: ProtocolParser) {
@@ -291,5 +350,43 @@ class InputLeapConnection(
         writer = null
         sharedDin = null
         sharedParser = null
+    }
+
+    companion object {
+        internal fun selectFailureToReport(
+            current: ConnectResult.Failed?,
+            candidate: ConnectResult.Failed,
+        ): ConnectResult.Failed {
+            val candidatePriority = failurePriority(candidate.reason)
+            val currentPriority = current?.let { failurePriority(it.reason) }
+            return if (currentPriority == null || candidatePriority > currentPriority) {
+                candidate
+            } else {
+                current
+            }
+        }
+
+        private fun failurePriority(reason: ConnectResult.FailureReason): Int = when (reason) {
+            ConnectResult.FailureReason.CERTIFICATE_MISMATCH,
+            ConnectResult.FailureReason.INCOMPATIBLE,
+            ConnectResult.FailureReason.BUSY -> 4
+            ConnectResult.FailureReason.NETWORK -> 3
+            ConnectResult.FailureReason.HANDSHAKE -> 2
+            ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER -> 1
+        }
+
+        internal fun isCertificateMismatch(error: Exception): Boolean =
+            generateSequence<Throwable>(error) { it.cause }
+                .any { "certificate fingerprint mismatch" in it.message.orEmpty().lowercase() }
+
+        internal fun isPlainServerTlsError(error: Exception): Boolean {
+            val causes = generateSequence<Throwable>(error) { it.cause }.toList()
+            val message = causes.joinToString(" ") { it.message.orEmpty() }.lowercase()
+            return causes.any { it is SSLException } && (
+                "unable to parse tls packet header" in message ||
+                    "not an sslv2 hello" in message ||
+                    "unsupported or unrecognized ssl message" in message
+            )
+        }
     }
 }

--- a/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
+++ b/app/src/main/java/com/inputleaf/android/network/InputLeapConnection.kt
@@ -55,7 +55,6 @@ class InputLeapConnection(
             val transports = TransportPolicy.order(
                 policy = transportPolicy,
                 preferredTransport = preferredTransport,
-                hasPinnedFingerprint = pinnedFingerprint != null,
             )
             var lastFailure: ConnectResult.Failed? = null
             for (transport in transports) {
@@ -201,11 +200,14 @@ class InputLeapConnection(
         } else {
             PLAIN_CONNECT_TIMEOUT_MS
         }
-        return Socket().apply {
-            connect(InetSocketAddress(ip, port), connectTimeout)
-            tcpNoDelay = true
-            soTimeout = HANDSHAKE_READ_TIMEOUT_MS
-        }
+        // Resolve the destination before touching Socket. Inside Socket.apply,
+        // `port` is Socket.port (0 until connected), not Deskflow's 24800.
+        val destination = InetSocketAddress(ip, port)
+        val socket = Socket()
+        socket.connect(destination, connectTimeout)
+        socket.tcpNoDelay = true
+        socket.soTimeout = HANDSHAKE_READ_TIMEOUT_MS
+        return socket
     }
 
     /**

--- a/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
+++ b/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
@@ -1,0 +1,31 @@
+package com.inputleaf.android.network
+
+object TransportPolicy {
+    fun order(
+        policy: ConnectionTransportPolicy,
+        preferredTransport: ServerTransport?,
+        hasPinnedFingerprint: Boolean,
+    ): List<ServerTransport> = when (policy) {
+        ConnectionTransportPolicy.TLS_ONLY -> listOf(ServerTransport.TLS)
+        ConnectionTransportPolicy.PLAIN_ONLY -> listOf(ServerTransport.PLAIN)
+        ConnectionTransportPolicy.AUTO -> autoOrder(preferredTransport, hasPinnedFingerprint)
+    }
+
+    private fun autoOrder(
+        preferredTransport: ServerTransport?,
+        hasPinnedFingerprint: Boolean,
+    ): List<ServerTransport> {
+        if (preferredTransport != null) {
+            val fallback = when (preferredTransport) {
+                ServerTransport.TLS -> ServerTransport.PLAIN
+                ServerTransport.PLAIN -> ServerTransport.TLS
+            }
+            return listOf(preferredTransport, fallback)
+        }
+        return if (hasPinnedFingerprint) {
+            listOf(ServerTransport.TLS, ServerTransport.PLAIN)
+        } else {
+            listOf(ServerTransport.PLAIN, ServerTransport.TLS)
+        }
+    }
+}

--- a/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
+++ b/app/src/main/java/com/inputleaf/android/network/TransportPolicy.kt
@@ -4,16 +4,14 @@ object TransportPolicy {
     fun order(
         policy: ConnectionTransportPolicy,
         preferredTransport: ServerTransport?,
-        hasPinnedFingerprint: Boolean,
     ): List<ServerTransport> = when (policy) {
         ConnectionTransportPolicy.TLS_ONLY -> listOf(ServerTransport.TLS)
         ConnectionTransportPolicy.PLAIN_ONLY -> listOf(ServerTransport.PLAIN)
-        ConnectionTransportPolicy.AUTO -> autoOrder(preferredTransport, hasPinnedFingerprint)
+        ConnectionTransportPolicy.AUTO -> autoOrder(preferredTransport)
     }
 
     private fun autoOrder(
         preferredTransport: ServerTransport?,
-        hasPinnedFingerprint: Boolean,
     ): List<ServerTransport> {
         if (preferredTransport != null) {
             val fallback = when (preferredTransport) {
@@ -22,10 +20,8 @@ object TransportPolicy {
             }
             return listOf(preferredTransport, fallback)
         }
-        return if (hasPinnedFingerprint) {
-            listOf(ServerTransport.TLS, ServerTransport.PLAIN)
-        } else {
-            listOf(ServerTransport.PLAIN, ServerTransport.TLS)
-        }
+        // Deskflow is TLS by default. Probing TLS first fails fast on plain servers;
+        // probing plain first stalls for the handshake timeout on TLS servers.
+        return listOf(ServerTransport.TLS, ServerTransport.PLAIN)
     }
 }

--- a/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
+++ b/app/src/main/java/com/inputleaf/android/service/ConnectionService.kt
@@ -13,6 +13,7 @@ import android.view.WindowManager
 import com.inputleaf.android.model.ConnectionState
 import com.inputleaf.android.model.InputLeapEvent
 import com.inputleaf.android.network.ConnectResult
+import com.inputleaf.android.network.ConnectionTransportPolicy
 import com.inputleaf.android.network.InputLeapConnection
 import com.inputleaf.android.network.ServerTransport
 import com.inputleaf.android.network.TlsFingerprintManager
@@ -109,6 +110,7 @@ class ConnectionService : Service() {
 
     var onFingerprintConfirmationRequired: (suspend (ip: String, fp: String, oldFp: String?) -> Boolean)? = null
     var onConnectionRejected: (() -> Unit)? = null
+    var onConnectionFailed: ((reason: ConnectResult.FailureReason, detail: String?) -> Unit)? = null
 
     fun connect(serverIp: String, screenName: String, force: Boolean = false) {
         val currentState = stateMachine.state.value
@@ -136,23 +138,31 @@ class ConnectionService : Service() {
 
     private suspend fun performConnect(serverIp: String, screenName: String, generation: Int) {
         if (generation != connectGeneration) return
+        var activePolicy = ConnectionTransportPolicy.AUTO
         try {
             startForeground(NOTIF_ID, NotificationHelper.build(this@ConnectionService, stateMachine.state.value))
             stateMachine.onConnecting(serverIp)
 
             val storedFp = prefs.fingerprintFor(serverIp).first()
-            val cachedTransport = prefs.transportFor(serverIp).first()?.let { mode ->
-                when (mode.lowercase()) {
-                    "tls" -> ServerTransport.TLS
-                    "plain" -> ServerTransport.PLAIN
-                    else -> null
+            activePolicy = prefs.connectionTransportPolicy.first()
+            val cachedTransport =
+                if (activePolicy == ConnectionTransportPolicy.AUTO) {
+                    prefs.transportFor(serverIp).first()?.let { mode ->
+                        when (mode.lowercase()) {
+                            "tls" -> ServerTransport.TLS
+                            "plain" -> ServerTransport.PLAIN
+                            else -> null
+                        }
+                    }
+                } else {
+                    null
                 }
-            }
 
             val conn = InputLeapConnection(
                 ip = serverIp,
                 preferredTransport = cachedTransport,
                 pinnedFingerprint = storedFp,
+                transportPolicy = activePolicy,
             ) { cert ->
                 val newFp = TlsFingerprintManager.fingerprintOf(cert)
                 val trusted = when {
@@ -196,11 +206,15 @@ class ConnectionService : Service() {
                     stateMachine.onDisconnected()
                     onConnectionRejected?.invoke()
                 }
-                is ConnectResult.NetworkError -> {
+                is ConnectResult.Failed -> {
                     conn.close()
-                    prefs.clearTransport(serverIp)
                     stateMachine.onDisconnected()
-                    scheduleRetry(serverIp, screenName, generation)
+                    if (activePolicy.shouldRetry(result.reason)) {
+                        prefs.clearTransport(serverIp)
+                        scheduleRetry(serverIp, screenName, generation)
+                    } else {
+                        onConnectionFailed?.invoke(result.reason, result.detail)
+                    }
                 }
             }
         } catch (e: CancellationException) {
@@ -209,7 +223,11 @@ class ConnectionService : Service() {
             if (generation != connectGeneration) return
             Log.w(TAG, "Connection to $serverIp failed: ${e.javaClass.simpleName}: ${e.message}", e)
             stateMachine.onDisconnected()
-            scheduleRetry(serverIp, screenName, generation)
+            if (activePolicy.shouldRetry(ConnectResult.FailureReason.NETWORK)) {
+                scheduleRetry(serverIp, screenName, generation)
+            } else {
+                onConnectionFailed?.invoke(ConnectResult.FailureReason.NETWORK, e.message)
+            }
         }
     }
 

--- a/app/src/main/java/com/inputleaf/android/storage/AppPreferences.kt
+++ b/app/src/main/java/com/inputleaf/android/storage/AppPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
+import com.inputleaf.android.network.ConnectionTransportPolicy
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -25,6 +26,9 @@ class AppPreferences(private val context: Context) {
         // Fingerprints stored as "ip:fingerprint" joined by newline
         private val KEY_FINGERPRINTS     = stringPreferencesKey("tls_fingerprints")
         private val KEY_TRANSPORT_MODES  = stringPreferencesKey("server_transport_modes")
+        private val KEY_CONNECTION_TRANSPORT_POLICY =
+            stringPreferencesKey("connection_transport_policy")
+        private val KEY_LEGACY_TLS_ENABLED = booleanPreferencesKey("tls_enabled")
         private val KEY_INPUT_METHOD     = stringPreferencesKey("input_method")
         private val KEY_CURSOR_STYLE     = stringPreferencesKey("cursor_style")
 
@@ -79,6 +83,16 @@ class AppPreferences(private val context: Context) {
     val cursorStyle: Flow<String> =
         context.dataStore.data.map { it[KEY_CURSOR_STYLE] ?: "default" }
 
+    val connectionTransportPolicy: Flow<ConnectionTransportPolicy> =
+        context.dataStore.data.map { prefs ->
+            val storedPolicy = prefs[KEY_CONNECTION_TRANSPORT_POLICY]
+            if (storedPolicy == null && prefs[KEY_LEGACY_TLS_ENABLED] == true) {
+                ConnectionTransportPolicy.TLS_ONLY
+            } else {
+                ConnectionTransportPolicy.fromStorage(storedPolicy)
+            }
+        }
+
     val favoriteServers: Flow<Set<String>> =
         context.dataStore.data.map { prefs ->
             prefs[KEY_FAVORITE_SERVERS]?.split("\n")?.filter { it.isNotBlank() }?.toSet() ?: emptySet()
@@ -126,6 +140,12 @@ class AppPreferences(private val context: Context) {
     suspend fun saveCursorStyle(style: String) = context.dataStore.edit {
         it[KEY_CURSOR_STYLE] = style
     }
+
+    suspend fun saveConnectionTransportPolicy(policy: ConnectionTransportPolicy) =
+        context.dataStore.edit {
+            it[KEY_CONNECTION_TRANSPORT_POLICY] = policy.storageValue
+            it.remove(KEY_LEGACY_TLS_ENABLED)
+        }
 
     suspend fun toggleFavoriteServer(ip: String) = context.dataStore.edit { prefs ->
         val current = prefs[KEY_FAVORITE_SERVERS]?.split("\n")?.filter { it.isNotBlank() }?.toMutableSet() ?: mutableSetOf()

--- a/app/src/main/java/com/inputleaf/android/ui/LeafNavigation.kt
+++ b/app/src/main/java/com/inputleaf/android/ui/LeafNavigation.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.inputleaf.android.network.ConnectionTransportPolicy
 import com.inputleaf.android.ui.components.AnimatedBottomNavigation
 import com.inputleaf.android.ui.components.NavItem
 import com.inputleaf.android.util.BatteryOptimizationHelper
@@ -49,6 +50,9 @@ fun LeafNavigation(viewModel: MainViewModel) {
     val keyboardEnabled by viewModel.keyboardEnabled.collectAsState(initial = true)
     val favoriteServers by viewModel.favoriteServers.collectAsState(initial = emptySet())
     val inputMethod by viewModel.inputMethod.collectAsState(initial = "auto")
+    val connectionTransportPolicy by viewModel.connectionTransportPolicy.collectAsState(
+        initial = ConnectionTransportPolicy.AUTO
+    )
     val cursorStyle by viewModel.cursorStyle.collectAsState(initial = "default")
     val shizukuAvailable by viewModel.shizukuAvailable.collectAsState(initial = false)
     val accessibilityAvailable by viewModel.accessibilityAvailable.collectAsState(initial = false)
@@ -164,6 +168,7 @@ fun LeafNavigation(viewModel: MainViewModel) {
                     showCursor = showCursor,
                     themeMode = themeMode,
                     inputMethod = inputMethod,
+                    connectionTransportPolicy = connectionTransportPolicy,
                     cursorStyle = cursorStyle,
                     shizukuAvailable = shizukuAvailable,
                     accessibilityAvailable = accessibilityAvailable,
@@ -174,6 +179,9 @@ fun LeafNavigation(viewModel: MainViewModel) {
                     onShowCursorChange = { viewModel.saveShowCursor(it) },
                     onThemeModeChange = { viewModel.saveThemeMode(it) },
                     onInputMethodChange = { viewModel.saveInputMethod(it) },
+                    onConnectionTransportPolicyChange = {
+                        viewModel.saveConnectionTransportPolicy(it)
+                    },
                     onCursorStyleChange = { viewModel.saveCursorStyle(it) },
                     onRequestOverlayPermission = {
                         context.startActivity(

--- a/app/src/main/java/com/inputleaf/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/inputleaf/android/ui/MainViewModel.kt
@@ -10,10 +10,13 @@ import android.net.wifi.WifiManager
 import android.os.IBinder
 import android.os.PowerManager
 import android.provider.Settings
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.inputleaf.android.model.ConnectionState
 import com.inputleaf.android.model.ServerInfo
+import com.inputleaf.android.network.ConnectResult
+import com.inputleaf.android.network.ConnectionTransportPolicy
 import com.inputleaf.android.network.ServerScanner
 import com.inputleaf.android.service.ConnectionService
 import com.inputleaf.android.service.CursorOverlayService
@@ -21,7 +24,6 @@ import com.inputleaf.android.storage.AppPreferences
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import android.util.Log
 import rikka.shizuku.Shizuku
 import java.net.InetAddress
 import java.net.NetworkInterface
@@ -30,6 +32,23 @@ enum class ThemeMode {
     SYSTEM,
     LIGHT,
     DARK
+}
+
+internal fun connectionFailureMessage(
+    reason: ConnectResult.FailureReason,
+    detail: String? = null,
+): String = when (reason) {
+    ConnectResult.FailureReason.NETWORK -> "Could not reach the Deskflow server"
+    ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER ->
+        "Server is not using TLS. Select Auto or Plain only, or enable TLS in Deskflow."
+    ConnectResult.FailureReason.CERTIFICATE_MISMATCH ->
+        "Deskflow's TLS certificate changed. Remove the trusted server only if you expect this."
+    ConnectResult.FailureReason.HANDSHAKE ->
+        "Deskflow handshake failed on the selected transport"
+    ConnectResult.FailureReason.INCOMPATIBLE ->
+        detail ?: "Deskflow rejected this client's protocol version"
+    ConnectResult.FailureReason.BUSY ->
+        "This screen name is already connected to Deskflow"
 }
 
 class MainViewModel(app: Application) : AndroidViewModel(app) {
@@ -74,6 +93,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     val keyboardEnabled: Flow<Boolean> = prefs.keyboardEnabled
     val favoriteServers: Flow<Set<String>> = prefs.favoriteServers
     val inputMethod: Flow<String> = prefs.inputMethod
+    val connectionTransportPolicy: Flow<ConnectionTransportPolicy> =
+        prefs.connectionTransportPolicy
 
     val shizukuAvailable: Flow<Boolean> = permissionProvider.shizukuAvailable
     val accessibilityAvailable: Flow<Boolean> = permissionProvider.accessibilityAvailable
@@ -124,6 +145,9 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     fun toggleFavoriteServer(ip: String) { viewModelScope.launch { prefs.toggleFavoriteServer(ip) } }
     fun saveInputMethod(method: String) { viewModelScope.launch { prefs.saveInputMethod(method) } }
     fun saveCursorStyle(style: String) { viewModelScope.launch { prefs.saveCursorStyle(style) } }
+    fun saveConnectionTransportPolicy(policy: ConnectionTransportPolicy) {
+        viewModelScope.launch { prefs.saveConnectionTransportPolicy(policy) }
+    }
 
     // Called by UI after user taps Trust/Cancel in FingerprintDialog
     fun respondToFingerprint(request: FingerprintRequest, trusted: Boolean) {
@@ -153,6 +177,9 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
             }
             service!!.onConnectionRejected = {
                 _errorState.value = "Connection not trusted"
+            }
+            service!!.onConnectionFailed = { reason, detail ->
+                _errorState.value = connectionFailureMessage(reason, detail)
             }
             
             // Auto-connect to last server if enabled

--- a/app/src/main/java/com/inputleaf/android/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/inputleaf/android/ui/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.ui.res.painterResource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.BorderStroke
+import com.inputleaf.android.network.ConnectionTransportPolicy
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,6 +39,7 @@ fun SettingsScreen(
     showCursor: Boolean,
     themeMode: String,
     inputMethod: String,
+    connectionTransportPolicy: ConnectionTransportPolicy,
     cursorStyle: String,
     shizukuAvailable: Boolean,
     accessibilityAvailable: Boolean,
@@ -48,6 +50,7 @@ fun SettingsScreen(
     onShowCursorChange: (Boolean) -> Unit,
     onThemeModeChange: (String) -> Unit,
     onInputMethodChange: (String) -> Unit,
+    onConnectionTransportPolicyChange: (ConnectionTransportPolicy) -> Unit,
     onCursorStyleChange: (String) -> Unit,
     onRequestOverlayPermission: () -> Unit,
     onDeleteFingerprint: (String) -> Unit,
@@ -57,6 +60,7 @@ fun SettingsScreen(
     var showThemeDialog by remember { mutableStateOf(false) }
     var showEditNameDialog by remember { mutableStateOf(false) }
     var showInputMethodDialog by remember { mutableStateOf(false) }
+    var showTransportPolicyDialog by remember { mutableStateOf(false) }
     var showCursorStyleDialog by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -117,6 +121,21 @@ fun SettingsScreen(
                                 onCheckedChange = onAutoConnectChange
                             )
                         }
+                    )
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        thickness = 1.dp,
+                        modifier = Modifier.padding(start = 72.dp)
+                    )
+                    SettingsRow(
+                        icon = Icons.Rounded.Lock,
+                        title = "Connection security",
+                        subtitle = when (connectionTransportPolicy) {
+                            ConnectionTransportPolicy.AUTO -> "Auto (recommended)"
+                            ConnectionTransportPolicy.TLS_ONLY -> "TLS only"
+                            ConnectionTransportPolicy.PLAIN_ONLY -> "Plain only"
+                        },
+                        onClick = { showTransportPolicyDialog = true }
                     )
                     HorizontalDivider(
                         color = MaterialTheme.colorScheme.outlineVariant,
@@ -323,13 +342,59 @@ fun SettingsScreen(
         )
     }
 
+    if (showTransportPolicyDialog) {
+        AlertDialog(
+            onDismissRequest = { showTransportPolicyDialog = false },
+            title = { Text("Connection Security") },
+            text = {
+                Column {
+                    SettingsChoiceOption(
+                        text = "Auto (Recommended)",
+                        selected = connectionTransportPolicy == ConnectionTransportPolicy.AUTO,
+                        status = "Use the last working mode, with fallback",
+                        statusColor = Color.Gray,
+                        onClick = {
+                            onConnectionTransportPolicyChange(ConnectionTransportPolicy.AUTO)
+                            showTransportPolicyDialog = false
+                        }
+                    )
+                    SettingsChoiceOption(
+                        text = "TLS only",
+                        selected = connectionTransportPolicy == ConnectionTransportPolicy.TLS_ONLY,
+                        status = "Require an encrypted Deskflow connection",
+                        statusColor = Color.Gray,
+                        onClick = {
+                            onConnectionTransportPolicyChange(ConnectionTransportPolicy.TLS_ONLY)
+                            showTransportPolicyDialog = false
+                        }
+                    )
+                    SettingsChoiceOption(
+                        text = "Plain only",
+                        selected = connectionTransportPolicy == ConnectionTransportPolicy.PLAIN_ONLY,
+                        status = "Never attempt TLS",
+                        statusColor = Color.Gray,
+                        onClick = {
+                            onConnectionTransportPolicyChange(ConnectionTransportPolicy.PLAIN_ONLY)
+                            showTransportPolicyDialog = false
+                        }
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showTransportPolicyDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     if (showInputMethodDialog) {
         AlertDialog(
             onDismissRequest = { showInputMethodDialog = false },
             title = { Text("Select Input Method") },
             text = {
                 Column {
-                    InputMethodOption(
+                    SettingsChoiceOption(
                         text = "Auto (Recommended)",
                         selected = inputMethod == "auto",
                         status = "Available",
@@ -339,7 +404,7 @@ fun SettingsScreen(
                             showInputMethodDialog = false
                         }
                     )
-                    InputMethodOption(
+                    SettingsChoiceOption(
                         text = "Shizuku",
                         selected = inputMethod == "shizuku",
                         status = if (shizukuAvailable) "Available" else "Not running",
@@ -349,7 +414,7 @@ fun SettingsScreen(
                             showInputMethodDialog = false
                         }
                     )
-                    InputMethodOption(
+                    SettingsChoiceOption(
                         text = "Accessibility Service",
                         selected = inputMethod == "accessibility",
                         status = if (accessibilityAvailable) "Enabled" else "Disabled",
@@ -550,7 +615,7 @@ fun SettingsScreen(
 
 
 @Composable
-private fun InputMethodOption(
+private fun SettingsChoiceOption(
     text: String,
     selected: Boolean,
     status: String,

--- a/app/src/test/java/com/inputleaf/android/network/PlainServerTlsErrorTest.kt
+++ b/app/src/test/java/com/inputleaf/android/network/PlainServerTlsErrorTest.kt
@@ -1,0 +1,36 @@
+package com.inputleaf.android.network
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import javax.net.ssl.SSLException
+
+class PlainServerTlsErrorTest {
+    @Test fun `detects plain-server TLS packet errors`() {
+        assertThat(
+            InputLeapConnection.isPlainServerTlsError(
+                SSLException("Unable to parse TLS packet header")
+            )
+        ).isTrue()
+        assertThat(
+            InputLeapConnection.isPlainServerTlsError(
+                SSLException("Unsupported or unrecognized SSL message")
+            )
+        ).isTrue()
+    }
+
+    @Test fun `detects wrapped plain-server TLS errors`() {
+        val error = IllegalStateException(
+            "Handshake failed",
+            SSLException("Not an SSLv2 hello"),
+        )
+
+        assertThat(InputLeapConnection.isPlainServerTlsError(error)).isTrue()
+    }
+
+    @Test fun `does not confuse certificate failures with plain servers`() {
+        val error = SSLException("Certificate fingerprint mismatch")
+
+        assertThat(InputLeapConnection.isPlainServerTlsError(error)).isFalse()
+        assertThat(InputLeapConnection.isCertificateMismatch(error)).isTrue()
+    }
+}

--- a/app/src/test/java/com/inputleaf/android/network/TransportPolicyTest.kt
+++ b/app/src/test/java/com/inputleaf/android/network/TransportPolicyTest.kt
@@ -1,0 +1,142 @@
+package com.inputleaf.android.network
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class TransportPolicyTest {
+    @Test fun `TLS only never falls back to plain`() {
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.TLS_ONLY,
+                preferredTransport = ServerTransport.PLAIN,
+                hasPinnedFingerprint = false,
+            )
+        ).containsExactly(ServerTransport.TLS)
+    }
+
+    @Test fun `plain only never probes TLS`() {
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.PLAIN_ONLY,
+                preferredTransport = ServerTransport.TLS,
+                hasPinnedFingerprint = true,
+            )
+        ).containsExactly(ServerTransport.PLAIN)
+    }
+
+    @Test fun `auto tries the learned transport before its fallback`() {
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.AUTO,
+                preferredTransport = ServerTransport.TLS,
+                hasPinnedFingerprint = false,
+            )
+        ).containsExactly(ServerTransport.TLS, ServerTransport.PLAIN).inOrder()
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.AUTO,
+                preferredTransport = ServerTransport.PLAIN,
+                hasPinnedFingerprint = true,
+            )
+        ).containsExactly(ServerTransport.PLAIN, ServerTransport.TLS).inOrder()
+    }
+
+    @Test fun `auto uses a fingerprint as a TLS hint when no transport was learned`() {
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.AUTO,
+                preferredTransport = null,
+                hasPinnedFingerprint = true,
+            )
+        ).containsExactly(ServerTransport.TLS, ServerTransport.PLAIN).inOrder()
+    }
+
+    @Test fun `auto defaults to plain first for a new server`() {
+        assertThat(
+            TransportPolicy.order(
+                policy = ConnectionTransportPolicy.AUTO,
+                preferredTransport = null,
+                hasPinnedFingerprint = false,
+            )
+        ).containsExactly(ServerTransport.PLAIN, ServerTransport.TLS).inOrder()
+    }
+
+    @Test fun `unknown stored policy safely defaults to auto`() {
+        assertThat(ConnectionTransportPolicy.fromStorage("future_mode"))
+            .isEqualTo(ConnectionTransportPolicy.AUTO)
+        assertThat(ConnectionTransportPolicy.fromStorage(null))
+            .isEqualTo(ConnectionTransportPolicy.AUTO)
+    }
+
+    @Test fun `certificate and server rejections never downgrade to another transport`() {
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldFallbackWithinAttempt(
+                ConnectResult.FailureReason.CERTIFICATE_MISMATCH
+            )
+        ).isFalse()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldFallbackWithinAttempt(
+                ConnectResult.FailureReason.INCOMPATIBLE
+            )
+        ).isFalse()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldFallbackWithinAttempt(
+                ConnectResult.FailureReason.BUSY
+            )
+        ).isFalse()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldFallbackWithinAttempt(
+                ConnectResult.FailureReason.NETWORK
+            )
+        ).isTrue()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldFallbackWithinAttempt(
+                ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER
+            )
+        ).isTrue()
+    }
+
+    @Test fun `explicit policies never retry a failed connection`() {
+        for (policy in listOf(
+            ConnectionTransportPolicy.TLS_ONLY,
+            ConnectionTransportPolicy.PLAIN_ONLY,
+        )) {
+            for (reason in ConnectResult.FailureReason.entries) {
+                assertThat(policy.shouldRetry(reason)).isFalse()
+                assertThat(policy.shouldFallbackWithinAttempt(reason)).isFalse()
+            }
+        }
+    }
+
+    @Test fun `auto retries only transient connection and handshake failures`() {
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldRetry(ConnectResult.FailureReason.NETWORK)
+        ).isTrue()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldRetry(ConnectResult.FailureReason.HANDSHAKE)
+        ).isTrue()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldRetry(
+                ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER
+            )
+        ).isFalse()
+        assertThat(
+            ConnectionTransportPolicy.AUTO.shouldRetry(
+                ConnectResult.FailureReason.CERTIFICATE_MISMATCH
+            )
+        ).isFalse()
+    }
+
+    @Test fun `network failure is reported over a later transport mismatch`() {
+        val network = ConnectResult.Failed(ConnectResult.FailureReason.NETWORK, "refused")
+        val mismatch = ConnectResult.Failed(
+            ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER,
+            "not TLS",
+        )
+
+        assertThat(InputLeapConnection.selectFailureToReport(network, mismatch))
+            .isEqualTo(network)
+        assertThat(InputLeapConnection.selectFailureToReport(mismatch, network))
+            .isEqualTo(network)
+    }
+}

--- a/app/src/test/java/com/inputleaf/android/network/TransportPolicyTest.kt
+++ b/app/src/test/java/com/inputleaf/android/network/TransportPolicyTest.kt
@@ -9,7 +9,6 @@ class TransportPolicyTest {
             TransportPolicy.order(
                 policy = ConnectionTransportPolicy.TLS_ONLY,
                 preferredTransport = ServerTransport.PLAIN,
-                hasPinnedFingerprint = false,
             )
         ).containsExactly(ServerTransport.TLS)
     }
@@ -19,7 +18,6 @@ class TransportPolicyTest {
             TransportPolicy.order(
                 policy = ConnectionTransportPolicy.PLAIN_ONLY,
                 preferredTransport = ServerTransport.TLS,
-                hasPinnedFingerprint = true,
             )
         ).containsExactly(ServerTransport.PLAIN)
     }
@@ -29,36 +27,23 @@ class TransportPolicyTest {
             TransportPolicy.order(
                 policy = ConnectionTransportPolicy.AUTO,
                 preferredTransport = ServerTransport.TLS,
-                hasPinnedFingerprint = false,
             )
         ).containsExactly(ServerTransport.TLS, ServerTransport.PLAIN).inOrder()
         assertThat(
             TransportPolicy.order(
                 policy = ConnectionTransportPolicy.AUTO,
                 preferredTransport = ServerTransport.PLAIN,
-                hasPinnedFingerprint = true,
             )
         ).containsExactly(ServerTransport.PLAIN, ServerTransport.TLS).inOrder()
     }
 
-    @Test fun `auto uses a fingerprint as a TLS hint when no transport was learned`() {
+    @Test fun `auto uses TLS first even without a stored fingerprint`() {
         assertThat(
             TransportPolicy.order(
                 policy = ConnectionTransportPolicy.AUTO,
                 preferredTransport = null,
-                hasPinnedFingerprint = true,
             )
         ).containsExactly(ServerTransport.TLS, ServerTransport.PLAIN).inOrder()
-    }
-
-    @Test fun `auto defaults to plain first for a new server`() {
-        assertThat(
-            TransportPolicy.order(
-                policy = ConnectionTransportPolicy.AUTO,
-                preferredTransport = null,
-                hasPinnedFingerprint = false,
-            )
-        ).containsExactly(ServerTransport.PLAIN, ServerTransport.TLS).inOrder()
     }
 
     @Test fun `unknown stored policy safely defaults to auto`() {

--- a/app/src/test/java/com/inputleaf/android/ui/ConnectionFailureMessageTest.kt
+++ b/app/src/test/java/com/inputleaf/android/ui/ConnectionFailureMessageTest.kt
@@ -1,0 +1,30 @@
+package com.inputleaf.android.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.inputleaf.android.network.ConnectResult
+import org.junit.Test
+
+class ConnectionFailureMessageTest {
+    @Test fun `policy mismatch explains how to recover`() {
+        assertThat(
+            connectionFailureMessage(
+                ConnectResult.FailureReason.TLS_AGAINST_PLAIN_SERVER
+            )
+        ).contains("Select Auto or Plain only")
+    }
+
+    @Test fun `each connection failure has a user-facing message`() {
+        for (reason in ConnectResult.FailureReason.entries) {
+            assertThat(connectionFailureMessage(reason)).isNotEmpty()
+        }
+    }
+
+    @Test fun `incompatible server details are preserved`() {
+        assertThat(
+            connectionFailureMessage(
+                ConnectResult.FailureReason.INCOMPATIBLE,
+                "Server requires 2.0",
+            )
+        ).isEqualTo("Server requires 2.0")
+    }
+}


### PR DESCRIPTION
## Summary

- Add global **Auto**, **TLS only**, and **Plain only** connection policies while keeping the learned transport and fingerprint caches per server.
- Preserve existing probe/fallback behavior under Auto; explicit modes attempt exactly one transport and stop after a failed attempt instead of entering retry storms.
- Return structured connection failures for network, handshake, TLS/plain mismatch, certificate mismatch, incompatible protocol, and busy screen names.
- Prevent TLS certificate mismatches and server rejections from falling back to plaintext.
- Preserve the most useful failure when Auto exhausts both transports, avoiding a misleading TLS policy error after an earlier network failure.
- Persist the selected policy with a safe Auto default and migrate the earlier unreleased `tls_enabled=true` preference to TLS only.
- Add a Connection Security settings dialog and actionable user-facing errors.

## Test plan

- [x] `GRADLE_USER_HOME=/home/ayaan/.gradle ./gradlew --no-daemon -Pkotlin.compiler.execution.strategy=in-process :app:testDebugUnitTest :uhid-server:test :app:assembleDebug`
- [x] `git diff --check`
- [x] Unit tests cover all transport orders and unknown stored values
- [x] Unit tests prove explicit modes never fall back or retry-loop
- [x] Unit tests prove certificate/server rejection cannot downgrade to another transport
- [x] Unit tests cover TLS-against-plain error classification, wrapped SSL failures, certificate mismatch, and failure prioritization
- [x] Unit tests cover user-facing recovery messages
- [x] Manual: Auto connects to plain Deskflow
- [x] Manual: Auto connects to TLS Deskflow and remembers TLS
- [x] Manual: TLS only against plain Deskflow shows one actionable error without retries
- [x] Manual: Plain only against TLS Deskflow shows one handshake error without retries
- [x] Manual: changed pinned certificate never attempts plain fallback

## Stack

Rebased onto current `master` after #24 and #22. Diff is only transport policy, failure handling, persistence, and settings. Client certificates remain out of scope (#26).

## Summary by Sourcery

Add explicit Deskflow transport policies with safe fallback behavior, structured failures, persistence, and actionable connection settings.

New Features:
- Add Auto, TLS-only, and plain-only connection security policies with a settings UI.
- Provide actionable user-facing connection error messages for transport, certificate, protocol, and server-state failures.

Bug Fixes:
- Prevent certificate mismatches and server rejections from downgrading to plaintext.
- Stop explicit transport modes from falling back or entering connection retry loops.
- Fix plain-socket connections to use the configured Deskflow destination port.

Enhancements:
- Preserve per-server learned transport and certificate fingerprints while applying a global transport policy.
- Classify connection failures structurally and retain the most useful failure when Auto exhausts both transports.
- Persist transport policy with an Auto default and migrate the legacy TLS preference to TLS-only.

Tests:
- Add unit coverage for transport ordering, policy persistence defaults, fallback and retry behavior, failure classification, prioritization, and user-facing messages.