### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,7 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.con
     dependsOn(":uhid-server:buildDex")
 }
 
-tasks.matching { it.name.contains("lintVital") }.configureEach {
+tasks.matching { it.name.contains("lintVital", ignoreCase = true) }.configureEach {
     dependsOn(":uhid-server:buildDex")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,7 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.con
     dependsOn(":uhid-server:buildDex")
 }
 
-tasks.matching { it.name.contains("LintVital") }.configureEach {
+tasks.matching { it.name.contains("lintVital") }.configureEach {
     dependsOn(":uhid-server:buildDex")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.inputleaf.android"
         minSdk = 26
         targetSdk = 34
-        versionCode = 5
-        versionName = "1.3.1"
+        versionCode = 6
+        versionName = "1.4.0"
     }
     
     signingConfigs {
@@ -85,6 +85,10 @@ android {
 }
 
 tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.configureEach {
+    dependsOn(":uhid-server:buildDex")
+}
+
+tasks.matching { it.name.contains("LintVital") }.configureEach {
     dependsOn(":uhid-server:buildDex")
 }
 


### PR DESCRIPTION
## Summary
- Bump `versionName` to **1.4.0** and `versionCode` to **6** so this can ship as a new GitHub release after 1.3.1.
- Declare `:uhid-server:buildDex` as a dependency of lint-vital tasks so `assembleRelease` can produce the APKs.

## Test plan
- [x] CI `fast-jvm` green
- [x] `./gradlew :app:assembleRelease` produces `input-leaf_1.4.0_*.apk`

## Summary by Sourcery

Prepare the Android app for the 1.4.0 release and make release APK assembly reliably include the UHID server dex output.

Enhancements:
- Prepare the Android app for the 1.4.0 release by updating its version metadata.
- Ensure release APK builds run the UHID server dex task before vital lint checks.