### PR TITLE
ci: report JVM coverage with Kover and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,22 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - name: Install Android SDK packages
         run: sdkmanager "platforms;android-34" "build-tools;34.0.0"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6.3.0
 
       - name: Run fast JVM tests and generate coverage
         run: ./gradlew --no-daemon --stacktrace :app:testDebugUnitTest :uhid-server:test :koverXmlReportDebugJvm :uhid-server:jacocoTestReport
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload failed test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: fast-jvm-test-reports
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew --no-daemon --stacktrace :app:testDebugUnitTest :uhid-server:test :koverXmlReportDebugJvm :uhid-server:jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           # Fork PRs use Codecov's tokenless upload; trusted runs authenticate with OIDC.
           use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -39,8 +40,19 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run fast JVM tests
-        run: ./gradlew --no-daemon --stacktrace :app:testDebugUnitTest :uhid-server:test
+      - name: Run fast JVM tests and generate coverage
+        run: ./gradlew --no-daemon --stacktrace :app:testDebugUnitTest :uhid-server:test :koverXmlReportDebugJvm :uhid-server:jacocoTestReport
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          # Fork PRs use Codecov's tokenless upload; trusted runs authenticate with OIDC.
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          files: build/reports/kover/coverage-debug-jvm.xml,uhid-server/build/reports/jacoco/test/jacocoTestReport.xml
+          disable_search: true
+          # Codecov returns an authentication error until the upstream repository is enabled there.
+          # Its required patch status is enforced through upstream branch protection after setup.
+          fail_ci_if_error: false
 
       - name: Upload failed test reports
         if: failure()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,15 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kover {
+    currentProject {
+        createVariant("debugJvm") {
+            add("debug")
+        }
+    }
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,24 @@ plugins {
     id("com.android.library") version "8.7.0" apply false
     id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.9.9"
+}
+
+dependencies {
+    kover(project(":app"))
+}
+
+kover {
+    currentProject {
+        createVariant("debugJvm") {
+        }
+    }
+
+    reports {
+        variant("debugJvm") {
+            xml {
+                xmlFile = layout.buildDirectory.file("reports/kover/coverage-debug-jvm.xml").get().asFile
+            }
+        }
+    }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+
+comment:
+  layout: "header, diff, files"
+  behavior: default
+  require_changes: false
+  hide_project_coverage: false

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -82,7 +82,6 @@ Kover collects coverage from the local Android `debug` JVM tests. JaCoCo collect
 
 Codecov requires 100% patch coverage: every changed executable line must be exercised by the suite. This is a regression guardrail, not proof that a feature is behaviorally complete; tests must still assert the relevant observable behavior and edge cases.
 
-The repository administrator must first enable the upstream repository in Codecov (or configure its token/OIDC authentication), then enable Codecov's `patch/default` status as a required branch-protection check after the first report establishes the baseline. The upload does not fail CI until Codecov is configured, so a fork cannot block the fast test suite before that maintainer setup. The project status starts with Codecov's automatic target and a one-percentage-point tolerance; tighten it only after excluding generated and non-testable code deliberately.
 
 ## Current baseline
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Input Leaf uses a small, fast JVM test suite as the main feedback loop for local development and pull requests. Android emulator tests and coverage enforcement will be added separately so they do not slow down this required check.
+Input Leaf uses a small, fast JVM test suite and Kover coverage reporting as the main feedback loop for local development and pull requests. Android emulator tests remain outside this required check so it stays fast.
 
 ## Requirements
 
@@ -13,10 +13,10 @@ Input Leaf uses a small, fast JVM test suite as the main feedback loop for local
 From the repository root, run:
 
 ```sh
-./gradlew :app:testDebugUnitTest :uhid-server:test
+./gradlew :koverXmlReportDebugJvm :uhid-server:jacocoTestReport
 ```
 
-The same command runs in the `fast-jvm` GitHub Actions job. The app task runs local Android JVM tests. The UHID task runs plain Java JVM tests.
+The Kover task runs the app's local Android `debug` JVM tests and writes `build/reports/kover/coverage-debug-jvm.xml`. The JaCoCo task runs the UHID module's plain Java JVM tests and writes `uhid-server/build/reports/jacoco/test/jacocoTestReport.xml`. The same tasks run in the `fast-jvm` GitHub Actions job.
 
 ## Test locations and conventions
 
@@ -74,7 +74,15 @@ The required pull-request suite must not depend on:
 - Shizuku, accessibility, IME, or `/dev/uhid` access;
 - APK signing or release secrets.
 
-A small emulator smoke suite and coverage guardrails are planned as later, separate work. Lint and formatting are not part of the required test command because the repository does not currently configure dedicated formatting or static-analysis tooling.
+A small emulator smoke suite is planned as later, separate work. Lint and formatting are not part of the required test command because the repository does not currently configure dedicated formatting or static-analysis tooling.
+
+## Coverage guardrails
+
+Kover collects coverage from the local Android `debug` JVM tests. JaCoCo collects coverage from the Java-only UHID module because Kover's Gradle plugin does not create coverage variants for a pure Java project. Codecov uploads both JaCoCo-compatible XML reports on every CI run, merges them for reporting, and comments on pull requests with project and changed-line coverage.
+
+Codecov requires 100% patch coverage: every changed executable line must be exercised by the suite. This is a regression guardrail, not proof that a feature is behaviorally complete; tests must still assert the relevant observable behavior and edge cases.
+
+The repository administrator must first enable the upstream repository in Codecov (or configure its token/OIDC authentication), then enable Codecov's `patch/default` status as a required branch-protection check after the first report establishes the baseline. The upload does not fail CI until Codecov is configured, so a fork cannot block the fast test suite before that maintainer setup. The project status starts with Codecov's automatic target and a one-percentage-point tolerance; tighten it only after excluding generated and non-testable code deliberately.
 
 ## Current baseline
 

--- a/uhid-server/build.gradle.kts
+++ b/uhid-server/build.gradle.kts
@@ -1,4 +1,16 @@
-plugins { id("java") }
+plugins {
+    id("java")
+    id("jacoco")
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Summary

- add Kover coverage collection for Android debug JVM tests, rooted in the top-level Gradle project
- add JaCoCo coverage collection for the Java-only UHID module; Kover does not create coverage variants for pure Java projects
- upload both JaCoCo-compatible XML reports to Codecov, which merges them for project and patch reporting
- configure Codecov PR comments plus a 100% changed-line (patch) coverage target
- document coverage commands, scope, guardrails, and required Codecov/branch-protection setup

## Validation

- `git diff --check`
- GitHub Actions `fast-jvm` validates the Android Kover report and UHID JaCoCo report.

## Maintainer action required

1. Enable the upstream repository in Codecov, or configure Codecov token/OIDC authentication.
2. Confirm the first uploaded coverage report.
3. Configure upstream branch protection to require Codecov’s `patch/default` status.

Branch protection and Codecov activation cannot be changed from this fork PR. Until Codecov is activated, upload authentication errors do not fail the existing fast-JVM test check.

The project coverage status begins with Codecov’s automatic baseline target and a one-percentage-point tolerance. The patch target is 100% with no tolerance; adjust exclusions or the project baseline only after reviewing generated and non-testable code.

## Summary by Sourcery

Add JVM coverage reporting and Codecov enforcement to the fast-JVM test workflow.

New Features:
- Add JVM coverage collection for the Android app and Java-only UHID module, with merged XML report uploads to Codecov.
- Configure Codecov pull-request comments and enforce 100% changed-line coverage.

Enhancements:
- Document local and CI coverage commands, coverage scope, and guardrails.

Build:
- Add Kover and JaCoCo coverage configuration to the Gradle builds.

CI:
- Generate and upload coverage reports in the fast-JVM workflow with tokenless or OIDC Codecov authentication.
- Update GitHub Actions dependencies and grant workflow OIDC permissions.

Documentation:
- Update testing documentation to describe JVM coverage reporting, Codecov behavior, and coverage requirements.