### PR TITLE
ci: add Android coverage smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           # Fork PRs use Codecov's tokenless upload; trusted runs authenticate with OIDC.
           use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           files: build/reports/kover/coverage-debug-jvm.xml,uhid-server/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: jvm
           disable_search: true
           # Codecov returns an authentication error until the upstream repository is enabled there.
           # Its required patch status is enforced through upstream branch protection after setup.
@@ -65,5 +66,69 @@ jobs:
             app/build/test-results/
             uhid-server/build/reports/tests/
             uhid-server/build/test-results/
+          if-no-files-found: warn
+          retention-days: 7
+
+  android-coverage:
+    name: android-coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4.0.1
+
+      - name: Install Android SDK packages
+        run: sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      # app/build.gradle.kts signs debug builds with the gitignored project keystore;
+      # CI generates a throwaway key with the same credentials so the APKs install on the emulator.
+      - name: Generate CI signing keystore
+        run: keytool -genkeypair -keystore app/input-leaf.jks -storepass inputleaf123 -keypass inputleaf123 -alias input-leaf -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Input Leaf CI"
+
+      - name: Build debug APK and test APK
+        run: ./gradlew --no-daemon --stacktrace :app:assembleDebug :app:assembleDebugAndroidTest
+
+      - name: Run connected smoke tests and generate Android coverage
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          script: ./gradlew --no-daemon --stacktrace :app:createDebugCoverageReport
+
+      - name: Upload Android coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Fork PRs use Codecov's tokenless upload; trusted runs authenticate with OIDC.
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          files: app/build/reports/coverage/androidTest/debug/connected/report.xml
+          flags: android
+          disable_search: true
+          # Codecov returns an authentication error until the upstream repository is enabled there.
+          # Its required patch status is enforced through upstream branch protection after setup.
+          fail_ci_if_error: false
+
+      - name: Upload failed test reports
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: android-coverage-test-reports
+          path: |
+            app/build/reports/
+            app/build/outputs/androidTest-results/
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,24 @@ jobs:
       - name: Build debug APK and test APK
         run: ./gradlew --no-daemon --stacktrace :app:assembleDebug :app:assembleDebugAndroidTest
 
+      # The runner image exposes /dev/kvm but the user is not in the kvm group;
+      # without this udev rule the emulator falls back to -accel off (software
+      # emulation) and the connected tests hang until the job timeout.
+      - name: Enable KVM access for the emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run connected smoke tests and generate Android coverage
         uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 34
           target: google_apis
           arch: x86_64
-          script: ./gradlew --no-daemon --stacktrace :app:createDebugCoverageReport
+          disable-linux-hw-accel: false
+          # Guard so a stuck device fails the step instead of hanging to the job timeout.
+          script: timeout 1200 ./gradlew --no-daemon --stacktrace :app:createDebugCoverageReport
 
       - name: Upload Android coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,10 @@ jobs:
           api-level: 34
           target: google_apis
           arch: x86_64
+          # The smoke tests assume fresh-install app state; a brand-new AVD every run
+          # guarantees it. Never adopt AVD caching for this job.
+          avd-name: test
+          force-avd-creation: true
           disable-linux-hw-accel: false
           # Guard so a stuck device fails the step instead of hanging to the job timeout.
           script: timeout 1200 ./gradlew --no-daemon --stacktrace :app:createDebugCoverageReport

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,8 @@ android {
         targetSdk = 34
         versionCode = 7
         versionName = "1.4.1"
+        // JUnit4 runner so the androidTest classes are discovered on the emulator
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     
     signingConfigs {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,8 @@ android {
             // Use project keystore so debug APKs can always update over each other
             // regardless of which machine built them
             signingConfig = signingConfigs.getByName("release")
+            // JaCoCo-instrument debug APKs so connected Android tests feed the Codecov report
+            isTestCoverageEnabled = true
         }
         release {
             isMinifyEnabled = false
@@ -124,4 +126,12 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("com.google.truth:truth:1.4.5")
+
+    androidTestImplementation(composeBom)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test:core:1.6.1")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:rules:1.6.2")
+    androidTestImplementation("com.google.truth:truth:1.4.5")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
             // regardless of which machine built them
             signingConfig = signingConfigs.getByName("release")
             // JaCoCo-instrument debug APKs so connected Android tests feed the Codecov report
-            isTestCoverageEnabled = true
+            enableAndroidTestCoverage = true
         }
         release {
             isMinifyEnabled = false
@@ -132,6 +132,6 @@ dependencies {
     androidTestImplementation("androidx.test:core:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.2")
+    androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("com.google.truth:truth:1.4.5")
 }

--- a/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
@@ -19,7 +19,7 @@ class ConnectionServiceTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     @Test
-    fun `bound service exposes local binder and starts disconnected`() {
+    fun boundServiceExposesLocalBinderAndStartsDisconnected() {
         ServiceBinding(context, ConnectionService::class.java).use { binding ->
             val binder = binding.awaitBinder()
             assertThat(binder).isInstanceOf(ConnectionService.LocalBinder::class.java)
@@ -30,7 +30,7 @@ class ConnectionServiceTest {
     }
 
     @Test
-    fun `disconnect from bound service keeps state disconnected`() {
+    fun disconnectFromBoundServiceKeepsStateDisconnected() {
         ServiceBinding(context, ConnectionService::class.java).use { binding ->
             val service =
                 (binding.awaitBinder() as ConnectionService.LocalBinder).getService()

--- a/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
@@ -37,7 +37,7 @@ class ConnectionServiceTest {
 
             service.disconnect()
 
-            assertThat(service.state.value).isInstanceOf(ConnectionState.Disconnected::class.java)
+            assertThat(service.state.value).isEqualTo(ConnectionState.Disconnected)
         }
     }
 }

--- a/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/service/ConnectionServiceTest.kt
@@ -1,0 +1,43 @@
+package com.inputleaf.android.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.inputleaf.android.model.ConnectionState
+import com.inputleaf.android.testutil.ServiceBinding
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Smoke tests that bind the real [ConnectionService] on an emulator: the binder must come up,
+ * expose the service, and keep the connection state consistent across a user-initiated disconnect.
+ */
+@RunWith(AndroidJUnit4::class)
+class ConnectionServiceTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `bound service exposes local binder and starts disconnected`() {
+        ServiceBinding(context, ConnectionService::class.java).use { binding ->
+            val binder = binding.awaitBinder()
+            assertThat(binder).isInstanceOf(ConnectionService.LocalBinder::class.java)
+
+            val service = (binder as ConnectionService.LocalBinder).getService()
+            assertThat(service.state.value).isEqualTo(ConnectionState.Disconnected)
+        }
+    }
+
+    @Test
+    fun `disconnect from bound service keeps state disconnected`() {
+        ServiceBinding(context, ConnectionService::class.java).use { binding ->
+            val service =
+                (binding.awaitBinder() as ConnectionService.LocalBinder).getService()
+
+            service.disconnect()
+
+            assertThat(service.state.value).isInstanceOf(ConnectionState.Disconnected::class.java)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/inputleaf/android/testutil/ServiceBinding.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/testutil/ServiceBinding.kt
@@ -27,7 +27,11 @@ class ServiceBinding(
         private set
 
     init {
-        context.bindService(Intent(context, serviceClass), this, Context.BIND_AUTO_CREATE)
+        // Fail fast instead of masking a rejected bind behind awaitBinder()'s connect
+        // timeout; bound stays false so close() never unbinds an unregistered connection.
+        val boundSuccessfully =
+            context.bindService(Intent(context, serviceClass), this, Context.BIND_AUTO_CREATE)
+        check(boundSuccessfully) { "Failed to bind ${serviceClass.name}" }
         bound = true
     }
 

--- a/app/src/androidTest/java/com/inputleaf/android/testutil/ServiceBinding.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/testutil/ServiceBinding.kt
@@ -1,0 +1,61 @@
+package com.inputleaf.android.testutil
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Binds a service with `BIND_AUTO_CREATE` and blocks until `onServiceConnected` fires.
+ *
+ * Callers must [close] the binding (or use `use`) so the service is unbound before the
+ * next test starts, mirroring the explicit-cleanup convention of the JVM test fixtures.
+ */
+class ServiceBinding(
+    private val context: Context,
+    serviceClass: Class<*>,
+) : ServiceConnection, AutoCloseable {
+
+    private val connected = CountDownLatch(1)
+    private var bound = false
+
+    /** Binder received in [onServiceConnected], or null after [onServiceDisconnected]. */
+    var binder: IBinder? = null
+        private set
+
+    init {
+        context.bindService(Intent(context, serviceClass), this, Context.BIND_AUTO_CREATE)
+        bound = true
+    }
+
+    /** Blocks until the service connects, then returns its binder. */
+    fun awaitBinder(): IBinder {
+        check(connected.await(BIND_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            "Service did not connect within $BIND_TIMEOUT_MS ms"
+        }
+        return checkNotNull(binder)
+    }
+
+    override fun close() {
+        if (bound) {
+            context.unbindService(this)
+            bound = false
+        }
+    }
+
+    override fun onServiceConnected(name: ComponentName, service: IBinder) {
+        binder = service
+        connected.countDown()
+    }
+
+    override fun onServiceDisconnected(name: ComponentName) {
+        binder = null
+    }
+
+    private companion object {
+        const val BIND_TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
@@ -1,0 +1,52 @@
+package com.inputleaf.android.ui
+
+import android.Manifest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.rule.GrantPermissionRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+
+/**
+ * Smoke test that launches the real [MainActivity] on an emulator. A fresh install has no
+ * onboarding flag, so the first run must render the onboarding welcome page and advance
+ * through its pager controls.
+ */
+class MainActivitySmokeTest {
+
+    // MainActivity asks for POST_NOTIFICATIONS on API 33+; grant it up front so the system
+    // dialog cannot interfere with the composed UI under test.
+    private val permissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
+
+    private val composeRule = createAndroidComposeRule<MainActivity>()
+
+    // The permission must be granted before the activity launches and shows the system dialog.
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(permissionRule).around(composeRule)
+
+    private fun waitAndAssertText(text: String) {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText(text).assertIsDisplayed()
+    }
+
+    @Test
+    fun `fresh install shows onboarding welcome page`() {
+        waitAndAssertText("Welcome to Input Leaf")
+    }
+
+    @Test
+    fun `next button advances to shizuku permission page`() {
+        waitAndAssertText("Welcome to Input Leaf")
+
+        composeRule.onNodeWithText("Next").performClick()
+
+        waitAndAssertText("Shizuku Setup (Optional)")
+    }
+}

--- a/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
@@ -1,21 +1,30 @@
 package com.inputleaf.android.ui
 
 import android.Manifest
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.datastore.preferences.core.edit
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
+import com.inputleaf.android.storage.dataStore
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
 import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
 
 /**
  * Smoke test that launches the real [MainActivity] on an emulator. A fresh install has no
  * onboarding flag, so the first run must render the onboarding welcome page and advance
  * through its pager controls.
  */
+@RunWith(AndroidJUnit4::class)
 class MainActivitySmokeTest {
 
     // MainActivity asks for POST_NOTIFICATIONS on API 33+; grant it up front so the system
@@ -23,11 +32,23 @@ class MainActivitySmokeTest {
     private val permissionRule: GrantPermissionRule =
         GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
 
+    // The tests need fresh-install state, but an activity-launching compose rule evaluates
+    // before any @Before can run, so the reset must be a rule of its own. Clearing through
+    // the app's own DataStore singleton also covers reused local emulators that completed
+    // onboarding manually.
+    private val resetAppDataRule: ExternalResource = object : ExternalResource() {
+        override fun before() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            runBlocking { context.dataStore.edit { it.clear() } }
+        }
+    }
+
     private val composeRule = createAndroidComposeRule<MainActivity>()
 
-    // The permission must be granted before the activity launches and shows the system dialog.
+    // The permission grant and DataStore reset both complete before the activity launches.
     @get:Rule
-    val ruleChain: RuleChain = RuleChain.outerRule(permissionRule).around(composeRule)
+    val ruleChain: RuleChain =
+        RuleChain.outerRule(permissionRule).around(resetAppDataRule).around(composeRule)
 
     private fun waitAndAssertText(text: String) {
         composeRule.waitUntil(timeoutMillis = 10_000) {

--- a/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
+++ b/app/src/androidTest/java/com/inputleaf/android/ui/MainActivitySmokeTest.kt
@@ -37,12 +37,12 @@ class MainActivitySmokeTest {
     }
 
     @Test
-    fun `fresh install shows onboarding welcome page`() {
+    fun freshInstallShowsOnboardingWelcomePage() {
         waitAndAssertText("Welcome to Input Leaf")
     }
 
     @Test
-    fun `next button advances to shizuku permission page`() {
+    fun nextButtonAdvancesToShizukuPermissionPage() {
         waitAndAssertText("Welcome to Input Leaf")
 
         composeRule.onNodeWithText("Next").performClick()

--- a/app/src/main/java/com/inputleaf/android/storage/AppPreferences.kt
+++ b/app/src/main/java/com/inputleaf/android/storage/AppPreferences.kt
@@ -8,7 +8,8 @@ import com.inputleaf.android.network.ConnectionTransportPolicy
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-private val Context.dataStore by preferencesDataStore("inputleaf_prefs")
+// internal so instrumented tests can reset app state through the app's own singleton
+internal val Context.dataStore by preferencesDataStore("inputleaf_prefs")
 
 class AppPreferences(private val context: Context) {
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  notify:
+    # Two CI jobs upload coverage (fast-jvm and android-coverage). Codecov waits for
+    # both before publishing the combined project/patch status and the PR comment.
+    after_n_builds: 2
+
 coverage:
   status:
     project:
@@ -6,20 +12,8 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
-
-ignore:
-  - "app/src/main/java/com/inputleaf/android/ui/**"
-  - "app/src/main/java/com/inputleaf/android/service/**"
-  - "app/src/main/java/com/inputleaf/android/shizuku/**"
-  - "app/src/main/java/com/inputleaf/android/inject/AccessibilityInputService.kt"
-  - "app/src/main/java/com/inputleaf/android/inject/InputLeafIME.kt"
-  - "app/src/main/java/com/inputleaf/android/inject/AccessibilityInputInjector.kt"
-  - "app/src/main/java/com/inputleaf/android/inject/KeysymInjection.kt"
-  - "app/src/main/java/com/inputleaf/android/storage/ClientCertificateStore.kt"
-  - "app/src/main/java/com/inputleaf/android/storage/AppPreferences.kt"
-  - "app/src/main/java/com/inputleaf/android/InputLeafApplication.kt"
+        target: 100%
+        threshold: 0%
 
 comment:
   layout: "header, diff, files"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,12 +1,13 @@
 # Testing
 
-Input Leaf uses a small, fast JVM test suite and Kover coverage reporting as the main feedback loop for local development and pull requests. Android emulator tests remain outside this required check so it stays fast.
+Input Leaf uses a small, fast JVM test suite and Kover coverage reporting as the main feedback loop for local development and pull requests. Pull-request CI runs two parallel coverage jobs: `fast-jvm` runs the JVM suites (~2–4 minutes) and `android-coverage` runs a small emulator smoke suite (~8–15 minutes normally, ~20–25 minutes with cold caches). Codecov waits for both uploads before publishing the combined project and patch status.
 
 ## Requirements
 
 - JDK 17
 - Android SDK platform 34 and build tools 34.0.0
 - The checked-in Gradle Wrapper (`./gradlew`)
+- An API 34 Android emulator, only for the instrumented smoke suite
 
 ## Run the fast suite
 
@@ -17,6 +18,23 @@ From the repository root, run:
 ```
 
 The Kover task runs the app's local Android `debug` JVM tests and writes `build/reports/kover/coverage-debug-jvm.xml`. The JaCoCo task runs the UHID module's plain Java JVM tests and writes `uhid-server/build/reports/jacoco/test/jacocoTestReport.xml`. The same tasks run in the `fast-jvm` GitHub Actions job.
+
+## Run the instrumented smoke tests
+
+Start an API 34 emulator (or Android Studio's Device Manager), then run:
+
+```sh
+./gradlew :app:createDebugCoverageReport
+```
+
+This installs the debug and test APKs, runs every instrumented test under `app/src/androidTest`, and writes the JaCoCo XML report to `app/build/reports/coverage/androidTest/debug/connected/report.xml`. The same task runs in the `android-coverage` GitHub Actions job. Debug builds are JaCoCo-instrumented (`isTestCoverageEnabled = true`), so no extra setup is needed for coverage.
+
+Note that debug builds sign with the project keystore `app/input-leaf.jks`, which is gitignored. CI generates a throwaway keystore with the credentials hardcoded in `app/build.gradle.kts`; on a machine without the project keystore, create one the same way:
+
+```sh
+keytool -genkeypair -keystore app/input-leaf.jks -storepass inputleaf123 -keypass inputleaf123 \
+  -alias input-leaf -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Input Leaf"
+```
 
 ## Test locations and conventions
 
@@ -42,6 +60,16 @@ The UHID module is Java-only. Keep its tests in Java so test coverage does not a
 
 Socket lifecycle paths in `UhidServer.run()` are not covered by JVM unit tests because `android.net.LocalServerSocket` and `LocalSocket` come from a compile-only Android stub that throws at runtime. Keep explicit `finally` cleanup around both sockets rather than adding brittle stub-dependent tests.
 
+### Android instrumented smoke tests
+
+Place emulator smoke tests under:
+
+```text
+app/src/androidTest/java/com/inputleaf/android/<feature>/
+```
+
+Mirror the production package, name classes after the subject, and keep the suite small: these tests run on an emulator in CI on every pull request. They are smoke tests that launch real activities and bind real services to catch integration breakage the JVM suite cannot see — navigation rendering, service binding, lifecycle startup — not full behavioral coverage. Shared fixtures go in `app/src/androidTest/java/com/inputleaf/android/testutil/`.
+
 ### Generated UHID DEX asset
 
 The app consumes the UHID sidecar from generated build output rather than a committed binary. App asset-merge tasks automatically depend on `:uhid-server:buildDex`, so packaging the app always uses the current Java source.
@@ -66,7 +94,7 @@ This task requires Android platform 34 and build tools 34.0.0. It compiles again
 
 ## Suite boundaries
 
-The required pull-request suite must not depend on:
+The required `fast-jvm` JVM suite must not depend on:
 
 - an Android emulator or connected device;
 - a Deskflow installation or external server;
@@ -74,20 +102,22 @@ The required pull-request suite must not depend on:
 - Shizuku, accessibility, IME, or `/dev/uhid` access;
 - APK signing or release secrets.
 
-A small emulator smoke suite is planned as later, separate work. Lint and formatting are not part of the required test command because the repository does not currently configure dedicated formatting or static-analysis tooling.
+The parallel `android-coverage` job runs a small instrumented smoke suite that intentionally exercises the opposite: real activities, real service binding, and real APK installation on an API 34 emulator. It must stay smoke-sized — it runs on every pull request, and emulator startup dominates its wall-clock time. Lint and formatting are not part of the required test commands because the repository does not currently configure dedicated formatting or static-analysis tooling.
 
 ## Coverage guardrails
 
-Kover collects coverage from the local Android `debug` JVM tests. JaCoCo collects coverage from the Java-only UHID module because Kover's Gradle plugin does not create coverage variants for a pure Java project. Codecov uploads both JaCoCo-compatible XML reports on every CI run, merges them for reporting, and comments on pull requests with project and changed-line coverage.
+Kover collects coverage from the local Android `debug` JVM tests. JaCoCo collects coverage from the Java-only UHID module because Kover's Gradle plugin does not create coverage variants for a pure Java project. The `android-coverage` job collects a JaCoCo report from the connected smoke tests against the instrumented debug APK. Codecov uploads all three as XML (`jvm` and `android` flags), waits for both jobs (`after_n_builds: 2` in `codecov.yml`), merges them for reporting, and comments on pull requests with project and changed-line coverage.
 
-Codecov requires 100% patch coverage: every changed executable line must be exercised by the suite. This is a regression guardrail, not proof that a feature is behaviorally complete; tests must still assert the relevant observable behavior and edge cases.
+Codecov requires 100% patch coverage: every changed executable line must be exercised by one of the suites. This is a regression guardrail, not proof that a feature is behaviorally complete; tests must still assert the relevant observable behavior and edge cases.
 
 
 ## Current baseline
 
 The initial baseline was verified with JDK 17 and Android SDK 34 when the fast CI workflow was introduced:
 
-- `:app:testDebugUnitTest` passes and runs the app’s Kotlin behavior tests.
-- `:uhid-server:test` passes and runs the UHID module’s Java behavior tests.
+- `:app:testDebugUnitTest` passes and runs the app's Kotlin behavior tests.
+- `:uhid-server:test` passes and runs the UHID module's Java behavior tests.
 
-Before making changes, run the complete fast suite and treat failures as real regressions or document them explicitly. Do not skip, mute, or retry failing tests merely to produce a green build. GitHub Actions retains available test reports when the `fast-jvm` job fails.
+The `android-coverage` CI job verifies on the API 34 emulator that `:app:createDebugCoverageReport` passes and runs the service and onboarding smoke tests added with that job.
+
+Before making changes, run the complete fast suite and treat failures as real regressions or document them explicitly. Do not skip, mute, or retry failing tests merely to produce a green build. GitHub Actions retains available test reports when either CI job fails.


### PR DESCRIPTION
## Summary

- add a parallel `android-coverage` CI job that boots a hardware-accelerated API 34 emulator, runs connected service and Compose UI smoke tests, generates a JaCoCo XML report, and uploads it to Codecov
- retain the existing fast JVM/Kover/UHID report job (`flags: jvm`); the Android report uploads with `flags: android` and `codecov.yml` sets `after_n_builds: 2` so Codecov waits for both uploads before publishing its combined project/patch status and PR comment
- add deterministic Android service-binding and onboarding UI smoke coverage for `ConnectionService` and `MainActivity`
- report all application source to Codecov without ignore exceptions (the expanded `ui`/`service`/`shizuku` ignore globs are removed so untested code is flagged instead of hidden)

## Job details (`android-coverage`)

- API 34, `google_apis`, x86_64 emulator via `reactivecircus/android-emulator-runner@v2.38.0`
- udev rule grants the runner user KVM access (`-accel on`); without it the emulator falls back to software emulation and the connected tests hang — `disable-linux-hw-accel: false` is set explicitly
- debug + androidTest APKs are signed with a throwaway CI-generated keystore matching `app/build.gradle.kts` signing config
- `enableAndroidTestCoverage = true` + `testInstrumentationRunner = androidx.test.runner.AndroidJUnitRunner` wire JaCoCo instrumentation and JUnit4 discovery
- `createDebugCoverageReport` runs under a `timeout 1200` guard so a stuck device fails fast instead of hanging to the job timeout
- failed-run artifacts (reports, androidTest results) are uploaded for debugging

## Instrumentation tests

- `ConnectionServiceTest`: binds the real `ConnectionService` via a `ServiceBinding` helper; asserts the `LocalBinder` is exposed and the connection state stays `Disconnected` across a user-initiated disconnect
- `MainActivitySmokeTest`: Compose test launching the real `MainActivity`; asserts a fresh install renders the onboarding welcome page and that "Next" advances to the Shizuku setup page (`GrantPermissionRule` grants `POST_NOTIFICATIONS` up front)

## Validation

- all 4 connected tests pass on the API 34 emulator (`Starting 4 tests ... Finished 4 tests`)
- Android JaCoCo XML generated at `app/build/reports/coverage/androidTest/debug/connected/report.xml` and uploaded to Codecov
- both coverage uploads merge: Codecov now reports the full app surface (previously ignored UI/service code counts at 0% until covered)
- `codecov/patch`, `android-coverage`, `fast-jvm`, `qlty check` all green

## Expected timing

The jobs run in parallel. `fast-jvm` remains ~2–4 minutes; `android-coverage` measured 7–8 minutes on GitHub runners.

## Maintainer notes

- `codecov.yml` intentionally keeps the strict `patch` target (100%) and drops all `ignore` entries: with the emulator job in place, Android-only code is now exercised in CI instead of excluded from reporting.
- Part of #8 (coverage enforcement); complements #12's JVM-only test suite.

## Summary by Sourcery

Add parallel Android emulator smoke testing and integrated coverage reporting to enforce coverage across the full application.

New Features:
- Add Android emulator smoke coverage for service binding and onboarding UI flows.
- Upload Android JaCoCo coverage alongside existing JVM coverage in CI.

Enhancements:
- Expand Codecov reporting to the full application source surface and require complete patch coverage after both coverage uploads.
- Configure Android instrumentation coverage and document local and CI emulator test execution.

CI:
- Run Android API 34 coverage tests in a parallel, hardware-accelerated CI job with failure artifacts.

Documentation:
- Document the Android instrumented smoke suite, coverage workflow, and testing boundaries.

Tests:
- Add connected tests covering ConnectionService binding/state and MainActivity onboarding navigation.